### PR TITLE
Skip multi-gpu unit tests due to non-support for multi-GPU

### DIFF
--- a/tests/cupy_tests/cuda_tests/test_nccl.py
+++ b/tests/cupy_tests/cuda_tests/test_nccl.py
@@ -1,11 +1,12 @@
 import pickle
 import unittest
+import pytest
 
 import cupy
 from cupy import cuda
 from cupy.cuda import nccl
 from cupy import testing
-
+from cupy.cuda import runtime
 
 nccl_available = nccl.available
 
@@ -70,6 +71,8 @@ class TestNCCL(unittest.TestCase):
 
     @testing.multi_gpu(2)
     @unittest.skipUnless(nccl_version >= 2700, 'Using old NCCL')
+    @pytest.mark.skipif(runtime.is_hip,
+                        reason="rccl doesn't support multi-GPU")
     def test_send_recv(self):
         devs = [0, 1]
         comms = nccl.NcclCommunicator.initAll(devs)

--- a/tests/cupy_tests/fft_tests/test_cache.py
+++ b/tests/cupy_tests/fft_tests/test_cache.py
@@ -146,6 +146,8 @@ class TestPlanCache(unittest.TestCase):
             cache[next(iterator)[0]]
 
     @testing.multi_gpu(2)
+    @pytest.mark.skipif(runtime.is_hip,
+                        reason="hipFFT doesn't support multi-GPU")
     def test_LRU_cache5(self):
         # test if the LRU cache is thread-local
 
@@ -198,6 +200,8 @@ class TestPlanCache(unittest.TestCase):
         assert stdout.count('uninitialized') == n_devices - 2
 
     @testing.multi_gpu(2)
+    @pytest.mark.skipif(runtime.is_hip,
+                        reason="hipFFT doesn't support multi-GPU")
     def test_LRU_cache6(self):
         # test if each device has a separate cache
         cache0 = self.caches[0]


### PR DESCRIPTION
Skipped all multi-gpu fft tests due to non-support. ROCM will hang on unit tests if run on a multi-GPU machine. 