### PR TITLE
Add xfail for test_cumprod_huge_array

### DIFF
--- a/tests/cupy_tests/math_tests/test_sumprod.py
+++ b/tests/cupy_tests/math_tests/test_sumprod.py
@@ -733,6 +733,7 @@ class TestCumprod:
         return a.cumprod(axis=1)
 
     @testing.slow
+    @pytest.mark.xfail(runtime.is_hip, reason='Workload size is bigger than what ROCm/CUDA supports') 
     def test_cumprod_huge_array(self):
         size = 2 ** 32
         # Free huge memory for slow test


### PR DESCRIPTION
The test cupy_tests/math_tests/test_sumprod.py::TestCumprod::test_cumprod_huge_array has workload size bigger than that is supported by ROCm/CUDA. This PR adds xfail decorator for the same.
