### PR TITLE
[CuPy] Fix compilation issues for ROCm 5.6

### DIFF
--- a/cupy/cuda/cupy_cufft.h
+++ b/cupy/cuda/cupy_cufft.h
@@ -12,7 +12,7 @@
 #include <cufftXt.h>
 
 #elif defined(CUPY_USE_HIP)
-#include <hipfft.h>
+#include <hipfft/hipfft.h>
 
 extern "C" {
 

--- a/cupy/cuda/cupy_cufft.h
+++ b/cupy/cuda/cupy_cufft.h
@@ -13,7 +13,7 @@
 
 #elif defined(CUPY_USE_HIP)
 #include <hip/hip_version.h> //for HIP_VERSION
-#if HIP_VERSION >= 505
+#if HIP_VERSION >= 50530600 
 #include <hipfft/hipfft.h>
 #else
 #include <hipfft.h>

--- a/cupy/cuda/cupy_cufft.h
+++ b/cupy/cuda/cupy_cufft.h
@@ -12,7 +12,12 @@
 #include <cufftXt.h>
 
 #elif defined(CUPY_USE_HIP)
+#include <hip/hip_version.h> //for HIP_VERSION
+#if HIP_VERSION >= 505
 #include <hipfft/hipfft.h>
+#else
+#include <hipfft.h>
+#endif
 
 extern "C" {
 

--- a/cupy/random/cupy_distributions.cuh
+++ b/cupy/random/cupy_distributions.cuh
@@ -34,7 +34,7 @@ struct rk_binomial_state {
 // When compiling cython extensions with hip 4.0
 // gcc will be used, but the hiprand_kernel can only be compiled with llvm
 // so we need to explicitly declare stubs for the functions
-#if HIP_VERSION >= 505
+#if HIP_VERSION >= 50530600
 #include <hiprand/hiprand_kernel.h>
 #elif HIP_VERSION > 400
 #include <hiprand_kernel.h>

--- a/cupy/random/cupy_distributions.cuh
+++ b/cupy/random/cupy_distributions.cuh
@@ -35,7 +35,7 @@ struct rk_binomial_state {
 // gcc will be used, but the hiprand_kernel can only be compiled with llvm
 // so we need to explicitly declare stubs for the functions
 #if HIP_VERSION > 400
-#include <hiprand_kernel.h>
+#include <hiprand/hiprand_kernel.h>
 #else
 #include <hiprand.h>
 typedef struct {} hiprandState;

--- a/cupy/random/cupy_distributions.cuh
+++ b/cupy/random/cupy_distributions.cuh
@@ -34,8 +34,10 @@ struct rk_binomial_state {
 // When compiling cython extensions with hip 4.0
 // gcc will be used, but the hiprand_kernel can only be compiled with llvm
 // so we need to explicitly declare stubs for the functions
-#if HIP_VERSION > 400
+#if HIP_VERSION >= 505
 #include <hiprand/hiprand_kernel.h>
+#elif HIP_VERSION > 400
+#include <hiprand_kernel.h>
 #else
 #include <hiprand.h>
 typedef struct {} hiprandState;

--- a/cupy_backends/hip/cupy_hip_common.h
+++ b/cupy_backends/hip/cupy_hip_common.h
@@ -2,8 +2,8 @@
 #define INCLUDE_GUARD_HIP_CUPY_COMMON_H
 
 #include <hip/hip_runtime_api.h>
-#include <hipblas.h>
-#include <rocsolver.h>
+#include <hipblas/hipblas.h>
+#include <rocsolver/rocsolver.h>
 
 #define CUDA_VERSION 0
 

--- a/cupy_backends/hip/cupy_hip_common.h
+++ b/cupy_backends/hip/cupy_hip_common.h
@@ -2,8 +2,13 @@
 #define INCLUDE_GUARD_HIP_CUPY_COMMON_H
 
 #include <hip/hip_runtime_api.h>
+#if HIP_VERSION >= 50530600
 #include <hipblas/hipblas.h>
 #include <rocsolver/rocsolver.h>
+#else
+#include <hipblas.h>
+#include <rocsolver.h>
+#endif
 
 #define CUDA_VERSION 0
 

--- a/cupy_backends/hip/cupy_hipblas.h
+++ b/cupy_backends/hip/cupy_hipblas.h
@@ -2,7 +2,11 @@
 #define INCLUDE_GUARD_HIP_CUPY_HIPBLAS_H
 
 #include "cupy_hip_common.h"
+#if HIP_VERSION >= 505 
 #include <hipblas/hipblas.h>
+#else
+#include <hipblas.h>
+#endif
 #include <hip/hip_version.h>  // for HIP_VERSION
 #include <stdexcept>  // for gcc 10
 

--- a/cupy_backends/hip/cupy_hipblas.h
+++ b/cupy_backends/hip/cupy_hipblas.h
@@ -2,7 +2,7 @@
 #define INCLUDE_GUARD_HIP_CUPY_HIPBLAS_H
 
 #include "cupy_hip_common.h"
-#include <hipblas.h>
+#include <hipblas/hipblas.h>
 #include <hip/hip_version.h>  // for HIP_VERSION
 #include <stdexcept>  // for gcc 10
 

--- a/cupy_backends/hip/cupy_hipblas.h
+++ b/cupy_backends/hip/cupy_hipblas.h
@@ -2,7 +2,7 @@
 #define INCLUDE_GUARD_HIP_CUPY_HIPBLAS_H
 
 #include "cupy_hip_common.h"
-#if HIP_VERSION >= 505 
+#if HIP_VERSION >= 50530600 
 #include <hipblas/hipblas.h>
 #else
 #include <hipblas.h>

--- a/cupy_backends/hip/cupy_hipsparse.h
+++ b/cupy_backends/hip/cupy_hipsparse.h
@@ -2,7 +2,7 @@
 
 #ifndef INCLUDE_GUARD_HIP_CUPY_HIPSPARSE_H
 #define INCLUDE_GUARD_HIP_CUPY_HIPSPARSE_H
-#if HIP_VERSION >= 505
+#if HIP_VERSION >= 50530600
 #include <hipsparse/hipsparse.h>
 #else
 #include <hipsparse.h>

--- a/cupy_backends/hip/cupy_hipsparse.h
+++ b/cupy_backends/hip/cupy_hipsparse.h
@@ -2,7 +2,7 @@
 
 #ifndef INCLUDE_GUARD_HIP_CUPY_HIPSPARSE_H
 #define INCLUDE_GUARD_HIP_CUPY_HIPSPARSE_H
-#include <hipsparse.h>
+#include <hipsparse/hipsparse.h>
 #include <hip/hip_version.h>    // for HIP_VERSION
 #include <hip/library_types.h>  // for hipDataType
 #include <stdexcept>  // for gcc 10.0

--- a/cupy_backends/hip/cupy_hipsparse.h
+++ b/cupy_backends/hip/cupy_hipsparse.h
@@ -2,7 +2,11 @@
 
 #ifndef INCLUDE_GUARD_HIP_CUPY_HIPSPARSE_H
 #define INCLUDE_GUARD_HIP_CUPY_HIPSPARSE_H
+#if HIP_VERSION >= 505
 #include <hipsparse/hipsparse.h>
+#else
+#include <hipsparse.h>
+#endif
 #include <hip/hip_version.h>    // for HIP_VERSION
 #include <hip/library_types.h>  // for hipDataType
 #include <stdexcept>  // for gcc 10.0

--- a/cupy_backends/hip/cupy_rccl.h
+++ b/cupy_backends/hip/cupy_rccl.h
@@ -1,7 +1,11 @@
 #ifndef INCLUDE_GUARD_HIP_CUPY_RCCL_H
 #define INCLUDE_GUARD_HIP_CUPY_RCCL_H
-
+#include <hip/hip_version.h>
+#if HIP_VERSION >= 505
 #include <rccl/rccl.h>
+#else
+#include <rccl.h>
+#endif
 typedef hipStream_t cudaStream_t;
 
 #endif

--- a/cupy_backends/hip/cupy_rccl.h
+++ b/cupy_backends/hip/cupy_rccl.h
@@ -1,7 +1,7 @@
 #ifndef INCLUDE_GUARD_HIP_CUPY_RCCL_H
 #define INCLUDE_GUARD_HIP_CUPY_RCCL_H
 #include <hip/hip_version.h>
-#if HIP_VERSION >= 505
+#if HIP_VERSION >= 50530600 
 #include <rccl/rccl.h>
 #else
 #include <rccl.h>

--- a/cupy_backends/hip/cupy_rccl.h
+++ b/cupy_backends/hip/cupy_rccl.h
@@ -1,7 +1,7 @@
 #ifndef INCLUDE_GUARD_HIP_CUPY_RCCL_H
 #define INCLUDE_GUARD_HIP_CUPY_RCCL_H
 
-#include <rccl.h>
+#include <rccl/rccl.h>
 typedef hipStream_t cudaStream_t;
 
 #endif

--- a/install/cupy_builder/_features.py
+++ b/install/cupy_builder/_features.py
@@ -159,12 +159,12 @@ def get_features(ctx: Context) -> Dict[str, Feature]:
         'include': [
             'hip/hip_runtime_api.h',
             'hip/hiprtc.h',
-            'hipblas.h',
+            'hipblas/hipblas.h',
             'hiprand/hiprand.h',
-            'hipsparse.h',
-            'hipfft.h',
+            'hipsparse/hipsparse.h',
+            'hipfft/hipfft.h',
             'roctx.h',
-            'rocsolver.h',
+            'rocsolver/rocsolver.h',
         ],
         'libraries': [
             'amdhip64',  # was hiprtc and hip_hcc before ROCm 3.8.0
@@ -358,7 +358,7 @@ def get_features(ctx: Context) -> Dict[str, Feature]:
             'cupy_backends.cuda.libs.nccl',
         ],
         'include': [
-            'rccl.h',
+            'rccl/rccl.h',
         ],
         'libraries': [
             'rccl',

--- a/install/cupy_builder/_features.py
+++ b/install/cupy_builder/_features.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, List
 import cupy_builder.install_build as build
 import cupy_builder.install_utils as utils
 from cupy_builder import Context
+from cupy.cuda.runtime import runtimeGetVersion
 
 
 class Feature:
@@ -147,6 +148,7 @@ def get_features(ctx: Context) -> Dict[str, Feature]:
     # the HIP stubs (hip/cupy_*.h) would cause many symbols
     # to leak into all these modules even if unused. It's easier for all of
     # them to link to the same set of shared libraries.
+    runtime_hip_version = runtimeGetVersion()
     HIP_cuda_nvtx_cusolver = {
         # TODO(leofang): call this "rocm" or "hip" to avoid confusion?
         'name': 'cuda',
@@ -159,12 +161,12 @@ def get_features(ctx: Context) -> Dict[str, Feature]:
         'include': [
             'hip/hip_runtime_api.h',
             'hip/hiprtc.h',
-            'hipblas/hipblas.h',
+            'hipblas/hipblas.h' if runtime_hip_version >= 50530600 else 'hipblas.h',
             'hiprand/hiprand.h',
-            'hipsparse/hipsparse.h',
-            'hipfft/hipfft.h',
+            'hipsparse/hipsparse.h' if runtime_hip_version >= 50530600 else 'hipsparse.h',
+            'hipfft/hipfft.h' if runtime_hip_version >= 50530600 else 'hipfft.h',
             'roctx.h',
-            'rocsolver/rocsolver.h',
+            'rocsolver/rocsolver.h' if runtime_hip_version >= 50530600 else 'rocsolver.h',
         ],
         'libraries': [
             'amdhip64',  # was hiprtc and hip_hcc before ROCm 3.8.0
@@ -358,7 +360,7 @@ def get_features(ctx: Context) -> Dict[str, Feature]:
             'cupy_backends.cuda.libs.nccl',
         ],
         'include': [
-            'rccl/rccl.h',
+            'rccl/rccl.h' if runtime_hip_version >= 50530600 else 'rccl.h',
         ],
         'libraries': [
             'rccl',

--- a/install/cupy_builder/_features.py
+++ b/install/cupy_builder/_features.py
@@ -3,7 +3,6 @@ from typing import Any, Dict, List
 import cupy_builder.install_build as build
 import cupy_builder.install_utils as utils
 from cupy_builder import Context
-from cupy.cuda.runtime import runtimeGetVersion
 
 
 class Feature:
@@ -148,7 +147,7 @@ def get_features(ctx: Context) -> Dict[str, Feature]:
     # the HIP stubs (hip/cupy_*.h) would cause many symbols
     # to leak into all these modules even if unused. It's easier for all of
     # them to link to the same set of shared libraries.
-    runtime_hip_version = runtimeGetVersion()
+    rocm_version = utils.get_rocm_version()
     HIP_cuda_nvtx_cusolver = {
         # TODO(leofang): call this "rocm" or "hip" to avoid confusion?
         'name': 'cuda',
@@ -161,12 +160,12 @@ def get_features(ctx: Context) -> Dict[str, Feature]:
         'include': [
             'hip/hip_runtime_api.h',
             'hip/hiprtc.h',
-            'hipblas/hipblas.h' if runtime_hip_version >= 50530600 else 'hipblas.h',
+            'hipblas/hipblas.h' if rocm_version >= 560 else 'hipblas.h',
             'hiprand/hiprand.h',
-            'hipsparse/hipsparse.h' if runtime_hip_version >= 50530600 else 'hipsparse.h',
-            'hipfft/hipfft.h' if runtime_hip_version >= 50530600 else 'hipfft.h',
+            'hipsparse/hipsparse.h' if rocm_version >= 560 else 'hipsparse.h',
+            'hipfft/hipfft.h' if rocm_version >= 560 else 'hipfft.h',
             'roctx.h',
-            'rocsolver/rocsolver.h' if runtime_hip_version >= 50530600 else 'rocsolver.h',
+            'rocsolver/rocsolver.h' if rocm_version >= 560 else 'rocsolver.h',
         ],
         'libraries': [
             'amdhip64',  # was hiprtc and hip_hcc before ROCm 3.8.0
@@ -360,7 +359,7 @@ def get_features(ctx: Context) -> Dict[str, Feature]:
             'cupy_backends.cuda.libs.nccl',
         ],
         'include': [
-            'rccl/rccl.h' if runtime_hip_version >= 50530600 else 'rccl.h',
+            'rccl/rccl.h' if rocm_version >= 560 else 'rccl.h',
         ],
         'libraries': [
             'rccl',

--- a/install/cupy_builder/install_build.py
+++ b/install/cupy_builder/install_build.py
@@ -448,7 +448,7 @@ def check_nccl_version(compiler, settings):
                             #ifndef CUPY_USE_HIP
                             #include <nccl.h>
                             #else
-                            #include <rccl.h>
+                            #include <rccl/rccl.h>
                             #endif
                             #include <stdio.h>
                             #ifdef NCCL_MAJOR

--- a/install/cupy_builder/install_build.py
+++ b/install/cupy_builder/install_build.py
@@ -448,7 +448,12 @@ def check_nccl_version(compiler, settings):
                             #ifndef CUPY_USE_HIP
                             #include <nccl.h>
                             #else
+                            #include <hip/hip_version.h>
+                            #if HIP_VERSION >= 50530600
                             #include <rccl/rccl.h>
+                            #else
+                            #include <rccl.h>
+                            #endif
                             #endif
                             #include <stdio.h>
                             #ifdef NCCL_MAJOR

--- a/install/cupy_builder/install_utils.py
+++ b/install/cupy_builder/install_utils.py
@@ -20,3 +20,14 @@ def search_on_path(filenames: List[str]) -> Optional[str]:
             if os.path.exists(full):
                 return os.path.abspath(full)
     return None
+
+
+def get_rocm_version() -> int:
+    rocm_version = -1
+    if os.getenv("ROCM_HOME"):
+        rocm_home = os.getenv("ROCM_HOME")
+        version_path = os.path.join(rocm_home, ".info")
+        version_path = os.path.join(version_path, "version")
+        rocm_version = int(
+            open(version_path).read().split("-")[0].replace(".", ""))
+    return rocm_version

--- a/install/cupy_builder/install_utils.py
+++ b/install/cupy_builder/install_utils.py
@@ -25,9 +25,8 @@ def search_on_path(filenames: List[str]) -> Optional[str]:
 def get_rocm_version() -> int:
     rocm_version = -1
     if os.getenv("ROCM_HOME"):
-        rocm_home = os.getenv("ROCM_HOME")
-        version_path = os.path.join(rocm_home, ".info")
-        version_path = os.path.join(version_path, "version")
+        rocm_home = str(os.getenv("ROCM_HOME"))
+        version_path = os.path.join(rocm_home, ".info", "version")
         rocm_version = int(
             open(version_path).read().split("-")[0].replace(".", ""))
     return rocm_version


### PR DESCRIPTION
This PR fixes the compilation issues for ROCm5.6. This PR contains fixes for usage of deprecated apis which throw the compilation errors. [SWDEV-393310]