### PR TITLE
Fix NCCL backend with MPI failing tests

### DIFF
--- a/cupy/cuda/cupy_cufft.h
+++ b/cupy/cuda/cupy_cufft.h
@@ -12,7 +12,7 @@
 #include <cufftXt.h>
 
 #elif defined(CUPY_USE_HIP)
-#include <hipfft.h>
+#include <hipfft/hipfft.h>
 
 extern "C" {
 

--- a/cupy/random/cupy_distributions.cuh
+++ b/cupy/random/cupy_distributions.cuh
@@ -35,7 +35,7 @@ struct rk_binomial_state {
 // gcc will be used, but the hiprand_kernel can only be compiled with llvm
 // so we need to explicitly declare stubs for the functions
 #if HIP_VERSION > 400
-#include <hiprand_kernel.h>
+#include <hiprand/hiprand_kernel.h>
 #else
 #include <hiprand.h>
 typedef struct {} hiprandState;

--- a/cupy_backends/hip/cupy_hip_common.h
+++ b/cupy_backends/hip/cupy_hip_common.h
@@ -2,8 +2,8 @@
 #define INCLUDE_GUARD_HIP_CUPY_COMMON_H
 
 #include <hip/hip_runtime_api.h>
-#include <hipblas.h>
-#include <rocsolver.h>
+#include <hipblas/hipblas.h>
+#include <rocsolver/rocsolver.h>
 
 #define CUDA_VERSION 0
 

--- a/cupy_backends/hip/cupy_hipblas.h
+++ b/cupy_backends/hip/cupy_hipblas.h
@@ -2,7 +2,7 @@
 #define INCLUDE_GUARD_HIP_CUPY_HIPBLAS_H
 
 #include "cupy_hip_common.h"
-#include <hipblas.h>
+#include <hipblas/hipblas.h>
 #include <hip/hip_version.h>  // for HIP_VERSION
 #include <stdexcept>  // for gcc 10
 

--- a/cupy_backends/hip/cupy_hipsparse.h
+++ b/cupy_backends/hip/cupy_hipsparse.h
@@ -2,7 +2,7 @@
 
 #ifndef INCLUDE_GUARD_HIP_CUPY_HIPSPARSE_H
 #define INCLUDE_GUARD_HIP_CUPY_HIPSPARSE_H
-#include <hipsparse.h>
+#include <hipsparse/hipsparse.h>
 #include <hip/hip_version.h>    // for HIP_VERSION
 #include <hip/library_types.h>  // for hipDataType
 #include <stdexcept>  // for gcc 10.0

--- a/cupy_backends/hip/cupy_rccl.h
+++ b/cupy_backends/hip/cupy_rccl.h
@@ -1,7 +1,7 @@
 #ifndef INCLUDE_GUARD_HIP_CUPY_RCCL_H
 #define INCLUDE_GUARD_HIP_CUPY_RCCL_H
 
-#include <rccl.h>
+#include <rccl/rccl.h>
 typedef hipStream_t cudaStream_t;
 
 #endif

--- a/install/cupy_builder/_features.py
+++ b/install/cupy_builder/_features.py
@@ -159,12 +159,12 @@ def get_features(ctx: Context) -> Dict[str, Feature]:
         'include': [
             'hip/hip_runtime_api.h',
             'hip/hiprtc.h',
-            'hipblas.h',
+            'hipblas/hipblas.h',
             'hiprand/hiprand.h',
-            'hipsparse.h',
-            'hipfft.h',
+            'hipsparse/hipsparse.h',
+            'hipfft/hipfft.h',
             'roctx.h',
-            'rocsolver.h',
+            'rocsolver/rocsolver.h',
         ],
         'libraries': [
             'amdhip64',  # was hiprtc and hip_hcc before ROCm 3.8.0
@@ -358,7 +358,7 @@ def get_features(ctx: Context) -> Dict[str, Feature]:
             'cupy_backends.cuda.libs.nccl',
         ],
         'include': [
-            'rccl.h',
+            'rccl/rccl.h',
         ],
         'libraries': [
             'rccl',

--- a/install/cupy_builder/install_build.py
+++ b/install/cupy_builder/install_build.py
@@ -448,7 +448,7 @@ def check_nccl_version(compiler, settings):
                             #ifndef CUPY_USE_HIP
                             #include <nccl.h>
                             #else
-                            #include <rccl.h>
+                            #include <rccl/rccl.h>
                             #endif
                             #include <stdio.h>
                             #ifdef NCCL_MAJOR

--- a/tests/cupyx_tests/distributed_tests/comm_runner.py
+++ b/tests/cupyx_tests/distributed_tests/comm_runner.py
@@ -12,6 +12,7 @@ from cupyx.distributed._nccl_comm import NCCLBackend
 from cupyx.distributed._store import ExceptionAwareProcess
 from cupyx.scipy import sparse
 
+import time
 
 nccl_available = nccl.available
 
@@ -117,6 +118,7 @@ def reduce_scatter(dtype, use_mpi=False):
             N_WORKERS * 10, dtype='f').reshape(N_WORKERS, 10)
         out_array = cupy.zeros((10,), dtype='f')
 
+        time.sleep(1)
         comm.reduce_scatter(in_array, out_array, 10)
         testing.assert_allclose(out_array, 2 * in_array[rank])
 
@@ -188,6 +190,7 @@ def send_recv(dtype, use_mpi=False):
         in_array = cupy.arange(10, dtype='f')
         for i in range(N_WORKERS):
             out_array = cupy.zeros((10,), dtype='f')
+            time.sleep(1)
             comm.send_recv(in_array, out_array, i)
             testing.assert_allclose(out_array, in_array)
 
@@ -210,7 +213,7 @@ def scatter(dtype, use_mpi=False):
         in_array = 1 + cupy.arange(
             N_WORKERS * 10, dtype='f').reshape(N_WORKERS, 10)
         out_array = cupy.zeros((10,), dtype='f')
-
+        time.sleep(1)
         comm.scatter(in_array, out_array, root)
         if rank > 0:
             testing.assert_allclose(out_array, in_array[rank])
@@ -235,6 +238,7 @@ def gather(dtype, use_mpi=False):
         comm = NCCLBackend(N_WORKERS, rank, use_mpi=use_mpi)
         in_array = (rank + 1) * cupy.arange(10, dtype='f')
         out_array = cupy.zeros((N_WORKERS, 10), dtype='f')
+        time.sleep(1)
         comm.gather(in_array, out_array, root)
         if rank == root:
             expected = 1 + cupy.arange(N_WORKERS).reshape(N_WORKERS, 1)


### PR DESCRIPTION
This PR fixes https://github.com/ROCmSoftwarePlatform/frameworks-internal/issues/4135 (JIRA:https://ontrack-internal.amd.com/browse/SWDEV-393039)

Some NCCLBackendWithMPI tests are failing on ROCm 5.6. They are not failing on ROCm 5.4 and when run individually on ROCm 5.6. 

The failure seems to be because of a synchronization issue between threads. This PR adds sleep for the threads before comm operations to avoid the failure. The change has been tested multiple times on ROCm 5.6 and tests passed in all of them.

It also includes @lcskrishna's fix for compilation issues with ROCm 5.6 (https://github.com/lcskrishna/cupy/commit/f2381ddf003c4d8fb1261914a077cfabae76c1d6)