### PR TITLE
Unskip unit tests that work on ROCm 5.6

### DIFF
--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
@@ -1198,7 +1198,9 @@ class TestLOBPCG:
         return eigvals, _eigen_vec_transform(vecs, xp)
 
     @pytest.mark.xfail(
-        runtime.is_hip and driver.get_build_version() >= 5_00_00000,
+        runtime.is_hip and
+        (driver.get_build_version() >= 5_00_00000 and
+         driver.get_build_version() < 50530600),
         reason='ROCm 5.0+ may have a bug')
     def test_maxit_None(self):
         """Check lobpcg if maxit=None runs 20 iterations (the default)


### PR DESCRIPTION
As part of SWDEV-392298 unskipping the test that works on ROCm 5.6 and xfail for older versions. 