### PR TITLE
Unskip ndimage tests. 

### DIFF
--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_filters.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_filters.py
@@ -192,7 +192,6 @@ COMMON_FLOAT_PARAMS['dtype'] = [numpy.float32, numpy.float64]
 ))
 @testing.gpu
 @testing.with_requires('scipy')
-@pytest.mark.skipif(runtime.is_hip, reason='ROCm/HIP may have a bug')
 class TestFilter(FilterTestCaseBase):
 
     def _hip_skip_invalid_condition(self):
@@ -222,6 +221,7 @@ class TestFilter(FilterTestCaseBase):
                 pytest.xfail('ROCm/HIP may have a bug')
 
     @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp')
+    @pytest.mark.skipif(runtime.is_hip, reason='ROCm/HIP may have a bug')
     def test_filter(self, xp, scp):
         self._hip_skip_invalid_condition()
         if self.dtype == getattr(self, 'output', None):
@@ -230,7 +230,6 @@ class TestFilter(FilterTestCaseBase):
 
 
 @testing.with_requires('scipy')
-@pytest.mark.skipif(runtime.is_hip, reason='ROCm/HIP may have a bug')
 class TestNearestFilterEdgeCase:
 
     @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp')
@@ -307,7 +306,6 @@ def dummy_deriv_func(input, axis, output, mode, cval, *args, **kwargs):
 ))
 @testing.gpu
 @testing.with_requires('scipy')
-@pytest.mark.skipif(runtime.is_hip, reason='ROCm/HIP may have a bug')
 class TestFilterFast(FilterTestCaseBase):
 
     def _hip_skip_invalid_condition(self):
@@ -324,6 +322,7 @@ class TestFilterFast(FilterTestCaseBase):
             pytest.xfail('ROCm/HIP may have a bug')
 
     @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp')
+    @pytest.mark.skipif(runtime.is_hip, reason='ROCm/HIP may have a bug')
     def test_filter(self, xp, scp):
         self._hip_skip_invalid_condition()
         return self._filter(xp, scp)
@@ -373,7 +372,6 @@ class TestFilterFast(FilterTestCaseBase):
 ))
 @testing.gpu
 @testing.with_requires('scipy')
-@pytest.mark.skipif(runtime.is_hip, reason='ROCm/HIP may have a bug')
 class TestFilterComplexFast(FilterTestCaseBase):
 
     @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp')
@@ -455,7 +453,6 @@ def lt_pyfunc(x):
 ))
 @testing.gpu
 @testing.with_requires('scipy')
-@pytest.mark.skipif(runtime.is_hip, reason='ROCm/HIP may have a bug')
 class TestGenericFilter(FilterTestCaseBase):
 
     _func_or_kernels = {
@@ -522,7 +519,6 @@ void shift(const double* in, ptrdiff_t in_length,
 ))
 @testing.gpu
 @testing.with_requires('scipy')
-@pytest.mark.skipif(runtime.is_hip, reason='ROCm/HIP may have a bug')
 class TestGeneric1DFilter(FilterTestCaseBase):
     _func_or_kernels = {
         'shift_raw': shift_raw,
@@ -565,7 +561,6 @@ class TestGeneric1DFilter(FilterTestCaseBase):
 @testing.gpu
 # SciPy behavior fixed in 1.5.0: https://github.com/scipy/scipy/issues/11661
 @testing.with_requires('scipy>=1.5.0')
-@pytest.mark.skipif(runtime.is_hip, reason='ROCm/HIP may have a bug')
 class TestMirrorWithDim1(FilterTestCaseBase):
     @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp')
     def test_filter(self, xp, scp):
@@ -593,7 +588,6 @@ class TestMirrorWithDim1(FilterTestCaseBase):
 ))
 @testing.gpu
 @testing.with_requires('scipy')
-@pytest.mark.skipif(runtime.is_hip, reason='ROCm/HIP may have a bug')
 class TestShellSort(FilterTestCaseBase):
     @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp')
     def test_filter(self, xp, scp):
@@ -620,7 +614,6 @@ class TestShellSort(FilterTestCaseBase):
 ))
 @testing.gpu
 @testing.with_requires('scipy')
-@pytest.mark.skipif(runtime.is_hip, reason='ROCm/HIP may have a bug')
 class TestFortranOrder(FilterTestCaseBase):
     @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp')
     def test_filter(self, xp, scp):
@@ -648,7 +641,6 @@ class TestFortranOrder(FilterTestCaseBase):
 ))
 @testing.gpu
 @testing.with_requires('scipy')
-@pytest.mark.skipif(runtime.is_hip, reason='ROCm/HIP may have a bug')
 class TestWeightDtype(FilterTestCaseBase):
     @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp')
     def test_filter(self, xp, scp):
@@ -680,7 +672,6 @@ class TestWeightDtype(FilterTestCaseBase):
 ))
 @testing.gpu
 @testing.with_requires('scipy>=1.5.9')
-@pytest.mark.skipif(runtime.is_hip, reason='ROCm/HIP may have a bug')
 class TestWeightComplexDtype(FilterTestCaseBase):
 
     def _skip_noncomplex(self):
@@ -729,7 +720,6 @@ class TestWeightComplexDtype(FilterTestCaseBase):
 }))
 @testing.gpu
 @testing.with_requires('scipy')
-@pytest.mark.skipif(runtime.is_hip, reason='ROCm/HIP may have a bug')
 class TestSpecialWeightCases(FilterTestCaseBase):
     @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp',
                                  accept_error=ValueError)
@@ -768,7 +758,6 @@ class TestSpecialWeightCases(FilterTestCaseBase):
 }))
 @testing.gpu
 @testing.with_requires('scipy')
-@pytest.mark.skipif(runtime.is_hip, reason='ROCm/HIP may have a bug')
 class TestSpecialCases1D(FilterTestCaseBase):
     @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp',
                                  accept_error=RuntimeError)
@@ -785,7 +774,6 @@ class TestSpecialCases1D(FilterTestCaseBase):
 }))
 @testing.gpu
 @testing.with_requires('scipy')
-@pytest.mark.skipif(runtime.is_hip, reason='ROCm/HIP may have a bug')
 class TestInvalidAxis(FilterTestCaseBase):
     @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp',
                                  accept_error=ValueError)
@@ -820,7 +808,6 @@ class TestInvalidAxis(FilterTestCaseBase):
 }))
 @testing.gpu
 @testing.with_requires('scipy')
-@pytest.mark.skipif(runtime.is_hip, reason='ROCm/HIP may have a bug')
 class TestInvalidMode(FilterTestCaseBase):
     @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp',
                                  accept_error=RuntimeError)
@@ -840,7 +827,6 @@ class TestInvalidMode(FilterTestCaseBase):
 @testing.gpu
 # SciPy behavior fixed in 1.2.0: https://github.com/scipy/scipy/issues/822
 @testing.with_requires('scipy>=1.2.0')
-@pytest.mark.skipif(runtime.is_hip, reason='ROCm/HIP may have a bug')
 class TestInvalidOrigin(FilterTestCaseBase):
     @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp',
                                  accept_error=ValueError)

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_fourier.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_fourier.py
@@ -55,7 +55,6 @@ except ImportError:
 )
 @testing.gpu
 @testing.with_requires("scipy")
-@pytest.mark.skipif(runtime.is_hip, reason='ROCm/HIP may have a bug')
 class TestFourierShift:
 
     def _test_real_nd(self, xp, scp, x, real_axis):
@@ -144,7 +143,6 @@ class TestFourierShift:
 )
 @testing.gpu
 @testing.with_requires("scipy")
-@pytest.mark.skipif(runtime.is_hip, reason='ROCm/HIP may have a bug')
 class TestFourierGaussian:
 
     def _test_real_nd(self, xp, scp, x, real_axis):
@@ -233,7 +231,6 @@ class TestFourierGaussian:
 )
 @testing.gpu
 @testing.with_requires("scipy")
-@pytest.mark.skipif(runtime.is_hip, reason='ROCm/HIP may have a bug')
 class TestFourierUniform:
 
     def _test_real_nd(self, xp, scp, x, real_axis):
@@ -316,7 +313,6 @@ class TestFourierUniform:
 )
 @testing.gpu
 @testing.with_requires('scipy')
-@pytest.mark.skipif(runtime.is_hip, reason='ROCm/HIP may have a bug')
 class TestFourierEllipsoid():
     def _test_real_nd(self, xp, scp, x, real_axis):
         if x.ndim == 1 and scipy_version < '1.5.3':
@@ -388,7 +384,6 @@ class TestFourierEllipsoid():
 
 @testing.gpu
 @testing.with_requires('scipy')
-@pytest.mark.skipif(runtime.is_hip, reason='ROCm/HIP may have a bug')
 class TestFourierEllipsoidInvalid():
 
     # SciPy < 1.5 raises ValueError instead of AxisError

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_fourier.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_fourier.py
@@ -7,7 +7,6 @@ from cupy import testing
 import cupyx.scipy.fft  # NOQA
 import cupyx.scipy.fftpack  # NOQA
 import cupyx.scipy.ndimage  # NOQA
-from cupy.cuda import runtime
 
 try:
     # scipy.fft only available since SciPy 1.4.0

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_interpolation.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_interpolation.py
@@ -42,7 +42,6 @@ def _conditional_scipy_version_skip(mode, order):
 }))
 @testing.gpu
 @testing.with_requires('scipy')
-@pytest.mark.skipif(runtime.is_hip, reason='ROCm/HIP may have a bug')
 class TestMapCoordinates:
 
     _multiprocess_can_split = True
@@ -125,7 +124,6 @@ class TestMapCoordinates:
 }))
 @testing.gpu
 @testing.with_requires('scipy')
-@pytest.mark.skipif(runtime.is_hip, reason='ROCm/HIP may have a bug')
 class TestMapCoordinatesHalfInteger:
 
     def _map_coordinates(self, xp, scp, a, coordinates):
@@ -155,7 +153,6 @@ class TestMapCoordinatesHalfInteger:
 }))
 @testing.gpu
 @testing.with_requires('scipy')
-@pytest.mark.skipif(runtime.is_hip, reason='ROCm/HIP may have a bug')
 class TestAffineTransform:
 
     _multiprocess_can_split = True
@@ -241,7 +238,6 @@ class TestAffineTransform:
 
 @testing.gpu
 @testing.with_requires('scipy')
-@pytest.mark.skipif(runtime.is_hip, reason='ROCm/HIP may have a bug')
 class TestAffineExceptions:
 
     def test_invalid_affine_ndim(self):
@@ -330,7 +326,6 @@ class TestAffineExceptions:
 }))
 @testing.gpu
 @testing.with_requires('scipy')
-@pytest.mark.skipif(runtime.is_hip, reason='ROCm/HIP may have a bug')
 class TestAffineTransformTextureMemory:
 
     _multiprocess_can_split = True
@@ -417,7 +412,6 @@ class TestAffineTransformTextureMemory:
 
 @testing.gpu
 @testing.with_requires('opencv-python')
-@pytest.mark.skipif(runtime.is_hip, reason='ROCm/HIP may have a bug')
 class TestAffineTransformOpenCV:
 
     _multiprocess_can_split = True
@@ -459,7 +453,6 @@ class TestAffineTransformOpenCV:
 ))
 @testing.gpu
 @testing.with_requires('scipy')
-@pytest.mark.skipif(runtime.is_hip, reason='ROCm/HIP may have a bug')
 class TestRotate:
 
     _multiprocess_can_split = True
@@ -538,7 +531,6 @@ class TestRotate:
 @testing.gpu
 # Scipy older than 1.3.0 raises IndexError instead of ValueError
 @testing.with_requires('scipy>=1.3.0')
-@pytest.mark.skipif(runtime.is_hip, reason='ROCm/HIP may have a bug')
 class TestRotateExceptions:
 
     def test_rotate_invalid_plane(self):
@@ -560,7 +552,6 @@ class TestRotateExceptions:
 )
 @testing.gpu
 @testing.with_requires('scipy')
-@pytest.mark.skipif(runtime.is_hip, reason='ROCm/HIP may have a bug')
 class TestRotateAxes:
 
     _multiprocess_can_split = True
@@ -575,7 +566,6 @@ class TestRotateAxes:
 
 @testing.gpu
 @testing.with_requires('opencv-python')
-@pytest.mark.skipif(runtime.is_hip, reason='ROCm/HIP may have a bug')
 class TestRotateOpenCV:
 
     _multiprocess_can_split = True
@@ -611,7 +601,6 @@ class TestRotateOpenCV:
 ))
 @testing.gpu
 @testing.with_requires('scipy')
-@pytest.mark.skipif(runtime.is_hip, reason='ROCm/HIP may have a bug')
 class TestShift:
 
     _multiprocess_can_split = True
@@ -692,7 +681,6 @@ class TestShift:
     'cval': [cupy.nan, cupy.inf, -cupy.inf],
 }))
 @testing.gpu
-@pytest.mark.skipif(runtime.is_hip, reason='ROCm/HIP may have a bug')
 class TestInterpolationInvalidCval:
 
     def _prep_output(self, a):
@@ -772,7 +760,6 @@ class TestInterpolationInvalidCval:
 
 @testing.gpu
 @testing.with_requires('opencv-python')
-@pytest.mark.skipif(runtime.is_hip, reason='ROCm/HIP may have a bug')
 class TestShiftOpenCV:
 
     _multiprocess_can_split = True
@@ -800,7 +787,6 @@ class TestShiftOpenCV:
 }))
 @testing.gpu
 @testing.with_requires('scipy')
-@pytest.mark.skipif(runtime.is_hip, reason='ROCm/HIP may have a bug')
 class TestZoom:
 
     _multiprocess_can_split = True
@@ -864,7 +850,6 @@ class TestZoom:
     'mode': ['nearest', 'reflect', 'mirror', 'grid-wrap', 'grid-constant'],
 }))
 @testing.gpu
-@pytest.mark.skipif(runtime.is_hip, reason='ROCm/HIP may have a bug')
 class TestZoomOrder0IntegerGrid():
 
     def test_zoom_grid_by_int_order0(self):
@@ -889,7 +874,6 @@ class TestZoomOrder0IntegerGrid():
     'grid_mode': [False, True],
 }))
 @testing.gpu
-@pytest.mark.skipif(runtime.is_hip, reason='ROCm/HIP may have a bug')
 class TestZoomOutputSize1():
 
     @testing.for_float_dtypes(no_float16=True)
@@ -908,7 +892,6 @@ class TestZoomOutputSize1():
 )
 @testing.gpu
 @testing.with_requires('opencv-python')
-@pytest.mark.skipif(runtime.is_hip, reason='ROCm/HIP may have a bug')
 class TestZoomOpenCV:
 
     _multiprocess_can_split = True
@@ -947,7 +930,6 @@ class TestZoomOpenCV:
 }))
 @testing.gpu
 @testing.with_requires('scipy')
-@pytest.mark.skipif(runtime.is_hip, reason='ROCm/HIP may have a bug')
 class TestSplineFilter1d:
     @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp')
     def test_spline_filter1d(self, xp, scp):
@@ -973,7 +955,6 @@ class TestSplineFilter1d:
 # See #5537
 @testing.slow
 @testing.with_requires('scipy')
-@pytest.mark.skipif(runtime.is_hip, reason='ROCm/HIP may have a bug')
 class TestSplineFilter1dLargeArray:
 
     @pytest.mark.parametrize('mode', ['mirror', 'grid-wrap', 'reflect'])
@@ -1000,7 +981,6 @@ class TestSplineFilter1dLargeArray:
 }))
 @testing.gpu
 @testing.with_requires('scipy')
-@pytest.mark.skipif(runtime.is_hip, reason='ROCm/HIP may have a bug')
 class TestSplineFilter:
     @testing.numpy_cupy_allclose(atol=1e-4, rtol=1e-4, scipy_name='scp')
     def test_spline_filter(self, xp, scp):
@@ -1041,7 +1021,6 @@ class TestSplineFilter:
 }))
 @testing.gpu
 @testing.with_requires('scipy')
-@pytest.mark.skipif(runtime.is_hip, reason='ROCm/HIP may have a bug')
 class TestSplineFilterComplex:
 
     @testing.with_requires('scipy>=1.6')

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_measurements.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_measurements.py
@@ -46,7 +46,6 @@ def _generate_binary_structure(rank, connectivity):
 }))
 @testing.gpu
 @testing.with_requires('scipy')
-@pytest.mark.skipif(runtime.is_hip, reason='ROCm/HIP may have a bug')
 class TestLabel:
 
     @testing.numpy_cupy_array_equal(scipy_name='scp')
@@ -72,7 +71,6 @@ class TestLabel:
 
 @testing.gpu
 @testing.with_requires('scipy')
-@pytest.mark.skipif(runtime.is_hip, reason='ROCm/HIP may have a bug')
 class TestLabelSpecialCases:
 
     @testing.numpy_cupy_array_equal(scipy_name='scp')
@@ -118,7 +116,6 @@ class TestLabelSpecialCases:
     'op': stats_ops,
 }))
 @testing.with_requires('scipy')
-@pytest.mark.skipif(runtime.is_hip, reason='ROCm/HIP may have a bug')
 class TestStats:
 
     def _make_image(self, shape, xp, dtype):
@@ -301,7 +298,6 @@ class TestStats:
     'enable_cub': [True, False],
 }))
 @testing.with_requires('scipy')
-@pytest.mark.skipif(runtime.is_hip, reason='ROCm/HIP may have a bug')
 class TestMeasurementsSelect:
 
     @pytest.fixture(autouse=True)
@@ -380,7 +376,6 @@ class TestMeasurementsSelect:
     'shape': [(200,), (16, 20)],
 }))
 @testing.with_requires('scipy')
-@pytest.mark.skipif(runtime.is_hip, reason='ROCm/HIP may have a bug')
 class TestHistogram():
 
     def _make_image(self, shape, xp, dtype, scale):
@@ -423,7 +418,6 @@ class TestHistogram():
     'pass_positions': [True, False],
 }))
 @testing.with_requires('scipy')
-@pytest.mark.skipif(runtime.is_hip, reason='ROCm/HIP may have a bug')
 class TestLabeledComprehension():
 
     def _make_image(self, shape, xp, dtype, scale):

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_morphology.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_morphology.py
@@ -2,7 +2,6 @@ import numpy
 import pytest
 
 from cupy import testing
-from cupy.cuda import runtime
 import cupyx.scipy.ndimage  # NOQA
 
 try:

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_morphology.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_morphology.py
@@ -25,7 +25,6 @@ except ImportError:
     {'rank': 3, 'connectivity': 500})
 @testing.gpu
 @testing.with_requires('scipy')
-@pytest.mark.skipif(runtime.is_hip, reason='ROCm/HIP may have a bug')
 class TestGenerateBinaryStructure:
 
     @testing.numpy_cupy_array_equal(scipy_name='scp')
@@ -36,7 +35,6 @@ class TestGenerateBinaryStructure:
 
 @testing.gpu
 @testing.with_requires('scipy')
-@pytest.mark.skipif(runtime.is_hip, reason='ROCm/HIP may have a bug')
 class TestIterateStructure:
 
     @testing.numpy_cupy_array_equal(scipy_name='scp')
@@ -77,7 +75,6 @@ class TestIterateStructure:
 )
 @testing.gpu
 @testing.with_requires('scipy')
-@pytest.mark.skipif(runtime.is_hip, reason='ROCm/HIP may have a bug')
 class TestBinaryErosionAndDilation1d:
     def _filter(self, xp, scp, x):
         filter = getattr(scp.ndimage, self.filter)
@@ -132,7 +129,6 @@ class TestBinaryErosionAndDilation1d:
 )
 @testing.gpu
 @testing.with_requires('scipy>=1.1.0')
-@pytest.mark.skipif(runtime.is_hip, reason='ROCm/HIP may have a bug')
 class TestBinaryOpeningAndClosing:
     def _filter(self, xp, scp, x):
         filter = getattr(scp.ndimage, self.filter)
@@ -184,7 +180,6 @@ class TestBinaryOpeningAndClosing:
 )
 @testing.gpu
 @testing.with_requires('scipy')
-@pytest.mark.skipif(runtime.is_hip, reason='ROCm/HIP may have a bug')
 class TestBinaryFillHoles:
     def _filter(self, xp, scp, x):
         filter = scp.ndimage.binary_fill_holes
@@ -234,7 +229,6 @@ class TestBinaryFillHoles:
 )
 @testing.gpu
 @testing.with_requires('scipy')
-@pytest.mark.skipif(runtime.is_hip, reason='ROCm/HIP may have a bug')
 class TestBinaryHitOrMiss:
     def _filter(self, xp, scp, x):
         filter = scp.ndimage.binary_hit_or_miss
@@ -308,7 +302,6 @@ class TestBinaryHitOrMiss:
 )
 @testing.gpu
 @testing.with_requires('scipy')
-@pytest.mark.skipif(runtime.is_hip, reason='ROCm/HIP may have a bug')
 class TestBinaryPropagation:
     def _filter(self, xp, scp, x):
         filter = scp.ndimage.binary_propagation
@@ -341,7 +334,6 @@ class TestBinaryPropagation:
 )
 @testing.gpu
 @testing.with_requires('scipy')
-@pytest.mark.skipif(runtime.is_hip, reason='ROCm/HIP may have a bug')
 class TestBinaryErosionAndDilation:
     def _filter(self, xp, scp, x):
         filter = getattr(scp.ndimage, self.filter)
@@ -379,7 +371,6 @@ class TestBinaryErosionAndDilation:
 )
 @testing.gpu
 @testing.with_requires('scipy')
-@pytest.mark.skipif(runtime.is_hip, reason='ROCm/HIP may have a bug')
 class TestBinaryErosionAndDilationContiguity:
     def _filter(self, xp, scp, x):
         filter = getattr(scp.ndimage, self.filter)
@@ -439,7 +430,6 @@ class TestBinaryErosionAndDilationContiguity:
 ))
 @testing.gpu
 @testing.with_requires('scipy')
-@pytest.mark.skipif(runtime.is_hip, reason='ROCm/HIP may have a bug')
 class TestGreyErosionAndDilation:
 
     def _filter(self, xp, scp, x):
@@ -486,7 +476,6 @@ class TestGreyErosionAndDilation:
 }))
 @testing.gpu
 @testing.with_requires('scipy')
-@pytest.mark.skipif(runtime.is_hip, reason='ROCm/HIP may have a bug')
 class TestGreyClosingAndOpening:
 
     shape = (4, 5)
@@ -537,7 +526,6 @@ class TestGreyClosingAndOpening:
 )
 @testing.gpu
 @testing.with_requires('scipy')
-@pytest.mark.skipif(runtime.is_hip, reason='ROCm/HIP may have a bug')
 class TestMorphologicalGradientAndLaplace:
 
     def _filter(self, xp, scp, x):
@@ -601,7 +589,6 @@ class TestMorphologicalGradientAndLaplace:
 )
 @testing.gpu
 @testing.with_requires('scipy')
-@pytest.mark.skipif(runtime.is_hip, reason='ROCm/HIP may have a bug')
 class TestWhiteTophatAndBlackTopHat:
 
     def _filter(self, xp, scp, x):


### PR DESCRIPTION
Unskip ndimage tests and skip tests those fail on rocm 5.4. 