### PR TITLE
add versioning to test_methods in test_generator

### DIFF
--- a/tests/cupy_tests/random_tests/test_generator.py
+++ b/tests/cupy_tests/random_tests/test_generator.py
@@ -14,6 +14,7 @@ from cupy import testing
 from cupy.testing import _attr
 from cupy.testing import _condition
 from cupy.testing import _hypothesis
+from cupy.cuda import driver
 
 from cupy_tests.random_tests import common_distributions
 
@@ -143,7 +144,8 @@ class TestRandomState(unittest.TestCase):
 
         for method in methods:
             if (runtime.is_hip and
-                    method == cupy.cuda.curand.CURAND_RNG_PSEUDO_MT19937):
+                    method == cupy.cuda.curand.CURAND_RNG_PSEUDO_MT19937
+                    and driver.get_build_version() < 50530600):
                 # hipRAND fails for MT19937 with the status code 1000,
                 # HIPRAND_STATUS_NOT_IMPLEMENTED. We use `pytest.raises` here
                 # so that we will be able to find it once hipRAND implement


### PR DESCRIPTION
This test has been passing from ROCm 5.6 version due to enablement of HIPRAND_RNG_PSEUDO_MT19937. 
So versioning to have keyerror only for versions below rocm 5.6