### PR TITLE
Update version for ROCm5.5 for test_linalg

### DIFF
--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
@@ -1200,7 +1200,7 @@ class TestLOBPCG:
     @pytest.mark.xfail(
         runtime.is_hip and
         (driver.get_build_version() >= 5_00_00000 and
-         driver.get_build_version() < 50530600),
+         driver.get_build_version() < 50530201),
         reason='ROCm 5.0+ may have a bug')
     def test_maxit_None(self):
         """Check lobpcg if maxit=None runs 20 iterations (the default)


### PR DESCRIPTION
The current test passes in rocm/pytorch:latest (ROCm 5.5), which has the driver version 50530201. Enabling this test from the latest version.


Test Run:

CUPY_TEST_GPU_LIMIT=4 CUPY_INSTALL_USE_HIP=1 pytest -vvv -k "not compile_cuda and not fft_allocate" -m "not slow" tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py::TestLOBPCG::test_maxit_None
============================================================================================================ test session starts ============================================================================================================
platform linux -- Python 3.8.16, pytest-7.3.1, pluggy-1.0.0 -- /opt/conda/bin/python
cachedir: .pytest_cache
hypothesis profile 'default' -> database=DirectoryBasedExampleDatabase('/var/lib/jenkins/cupy/.hypothesis/examples')
rootdir: /var/lib/jenkins/cupy
configfile: setup.cfg
plugins: rerunfailures-11.1.2, hypothesis-5.35.1, xdoctest-1.1.0, shard-0.1.2, flakefinder-1.1.0, xdist-3.2.1
collected 1 item
Running 1 items in this shard: tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py::TestLOBPCG::test_maxit_None

tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py::TestLOBPCG::test_maxit_None PASSED                                                                                                                                         [100%]

============================================================================================================= 1 passed in 2.14s =============================================================================================================