### PR TITLE
Change test pass condition for TestChoiceChi::test_goodness_of_fit

### DIFF
--- a/tests/cupy_tests/random_tests/test_generator.py
+++ b/tests/cupy_tests/random_tests/test_generator.py
@@ -855,8 +855,7 @@ class TestChoiceChi(RandomGeneratorTestCase):
 
     target_method = 'choice'
 
-    @_condition.repeat(3, 10)
-    @pytest.mark.xfail(runtime.is_hip, reason='ROCm/HIP may have a bug')
+    @_condition.repeat_with_success_at_least(10, 9)
     def test_goodness_of_fit(self):
         trial = 100
         vals = self.generate_many(3, 1, True, [0.3, 0.3, 0.4], _count=trial)


### PR DESCRIPTION
The TestChoiceChi::test_goodness_of_fit passing condition is changed in this PR based on upstream recommendation here: https://github.com/cupy/cupy/issues/7544#issuecomment-1566616536

This change is tested multiple times as attached in the log: [test_gof.log](https://github.com/ROCmSoftwarePlatform/cupy/files/11696751/test_gof.log)
