### PR TITLE
Fix Failing Linalg Tests Involving hipSolver

### DIFF
--- a/cupy/linalg/_eigenvalue.py
+++ b/cupy/linalg/_eigenvalue.py
@@ -141,7 +141,7 @@ def eigh(a, UPLO='L'):
         v = cupy.empty(a.shape, v_dtype)
         return w, v
 
-    if a.ndim > 2 or runtime.is_hip:
+    if a.ndim > 2:
         w, v = cupyx.cusolver.syevj(a, UPLO, True)
         return w, v
     else:


### PR DESCRIPTION
This PR fixes implementation causing linalg UT's to fail. 

- Removes old rocSolver workarounds for eign originally implemented in https://github.com/cupy/cupy/pull/5555/files causing a few UT's to fail. 
- New implementation is based on updated hipSolver library and is no longer needed. 

Failing UT's:
[failing_hipsolver_ut.log](https://github.com/ROCmSoftwarePlatform/cupy/files/13532526/failing_hipsolver_ut.log)

Passing UT's
[passing_hipsolver_ut.log](https://github.com/ROCmSoftwarePlatform/cupy/files/13532532/passing_hipsolver_ut.log)
