### PR TITLE
Enable cuda array interface for ROCm

### DIFF
--- a/cupy/_core/core.pyx
+++ b/cupy/_core/core.pyx
@@ -239,9 +239,6 @@ cdef class _ndarray_base:
 
     @property
     def __cuda_array_interface__(self):
-        if runtime._is_hip_environment:
-            raise AttributeError(
-                'HIP/ROCm does not support cuda array interface')
         cdef dict desc = {
             'shape': self.shape,
             'typestr': self.dtype.str,
@@ -1678,8 +1675,6 @@ cdef class _ndarray_base:
                 # `_kernel._preprocess_args`.
                 check = (hasattr(x, '__cuda_array_interface__')
                          or hasattr(x, '__cupy_get_ndarray__'))
-                if runtime._is_hip_environment and isinstance(x, ndarray):
-                    check = True
                 if (not check
                         and not type(x) in _scalar.scalar_type_set
                         and not isinstance(x, numpy.ndarray)):
@@ -2732,9 +2727,6 @@ cpdef _ndarray_base asfortranarray(_ndarray_base a, dtype=None):
 
 
 cpdef _ndarray_base _convert_object_with_cuda_array_interface(a):
-    if runtime._is_hip_environment:
-        raise RuntimeError(
-            'HIP/ROCm does not support cuda array interface')
 
     cdef Py_ssize_t sh, st
     cdef dict desc = a.__cuda_array_interface__

--- a/tests/cupy_tests/core_tests/test_ndarray.py
+++ b/tests/cupy_tests/core_tests/test_ndarray.py
@@ -323,8 +323,6 @@ class TestNdarrayCudaInterface(unittest.TestCase):
     'stream': ('null', 'new', 'ptds'),
     'ver': (2, 3),
 }))
-
-
 class TestNdarrayCudaInterfaceStream(unittest.TestCase):
     def setUp(self):
         if self.stream == 'null':
@@ -366,18 +364,22 @@ class TestNdarrayCudaInterfaceStream(unittest.TestCase):
                 assert iface['stream'] == stream.ptr
 
 
-class TestNdarrayCudaInterfaceNoneCUDA(unittest.TestCase):
+class TestNdarrayCudaInterfaceAttr(unittest.TestCase):
 
     def setUp(self):
         self.arr = cupy.zeros(shape=(2, 3), dtype=cupy.float64)
 
     def test_cuda_array_interface_hasattr(self):
-        assert not hasattr(self.arr, '__cuda_array_interface__')
+        assert hasattr(self.arr, '__cuda_array_interface__')
 
     def test_cuda_array_interface_getattr(self):
-        with pytest.raises(AttributeError) as e:
-            getattr(self.arr, '__cuda_array_interface__')
-        assert 'HIP' in str(e.value)
+        try:
+            interface = getattr(self.arr, '__cuda_array_interface__')
+            self.assertIsNotNone(interface)
+        except AttributeError as e:
+            self.fail(
+                "__cuda_array_interface__ should be present, "
+                f"but got an AttributeError: {str(e)}")
 
 
 @testing.parameterize(

--- a/tests/cupy_tests/core_tests/test_ndarray.py
+++ b/tests/cupy_tests/core_tests/test_ndarray.py
@@ -263,8 +263,6 @@ class TestNdarrayShape(unittest.TestCase):
             assert 'incompatible shape' in str(e.value).lower()
 
 
-@pytest.mark.skipif(cupy.cuda.runtime.is_hip,
-                    reason='HIP does not support this')
 class TestNdarrayCudaInterface(unittest.TestCase):
 
     def test_cuda_array_interface(self):
@@ -325,8 +323,8 @@ class TestNdarrayCudaInterface(unittest.TestCase):
     'stream': ('null', 'new', 'ptds'),
     'ver': (2, 3),
 }))
-@pytest.mark.skipif(cupy.cuda.runtime.is_hip,
-                    reason='HIP does not support this')
+
+
 class TestNdarrayCudaInterfaceStream(unittest.TestCase):
     def setUp(self):
         if self.stream == 'null':
@@ -368,8 +366,6 @@ class TestNdarrayCudaInterfaceStream(unittest.TestCase):
                 assert iface['stream'] == stream.ptr
 
 
-@pytest.mark.skipif(not cupy.cuda.runtime.is_hip,
-                    reason='This is supported on CUDA')
 class TestNdarrayCudaInterfaceNoneCUDA(unittest.TestCase):
 
     def setUp(self):

--- a/tests/cupy_tests/core_tests/test_ndarray_cuda_array_interface.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_cuda_array_interface.py
@@ -3,6 +3,7 @@ import pytest
 
 from cupy_backends.cuda import stream as stream_module
 import cupy
+import cupy_backends
 from cupy import _core
 from cupy import testing
 
@@ -27,8 +28,11 @@ class DummyObjectWithCudaArrayInterface(object):
             'version': self.ver,
         }
         if self.ver == 3:
-            stream = cupy.cuda.get_current_stream()
-            desc['stream'] = 1 if stream.ptr == 0 else stream.ptr
+            if not cupy_backends.cuda.api.runtime.is_hip:
+                desc['stream'] = cupy.cuda.runtime.streamLegacy if stream.ptr == 0 else stream.ptr
+            else: # Only non-default streams use their actual ptr values. (ROCm)
+                stream = cupy.cuda.get_current_stream()
+                desc['stream'] = stream.ptr
         return desc
 
 
@@ -36,8 +40,8 @@ class DummyObjectWithCudaArrayInterface(object):
     'stream': ('null', 'new'),
     'ver': (2, 3),
 }))
-@pytest.mark.skipif(cupy.cuda.runtime.is_hip,
-                    reason='HIP does not support this')
+
+
 class TestArrayUfunc(unittest.TestCase):
 
     def setUp(self):
@@ -72,8 +76,8 @@ class TestArrayUfunc(unittest.TestCase):
     'stream': ('null', 'new'),
     'ver': (2, 3),
 }))
-@pytest.mark.skipif(cupy.cuda.runtime.is_hip,
-                    reason='HIP does not support this')
+
+
 class TestElementwiseKernel(unittest.TestCase):
 
     def setUp(self):
@@ -109,8 +113,8 @@ class TestElementwiseKernel(unittest.TestCase):
     'stream': ('null', 'new'),
     'ver': (2, 3),
 }))
-@pytest.mark.skipif(cupy.cuda.runtime.is_hip,
-                    reason='HIP does not support this')
+
+
 class TestSimpleReductionFunction(unittest.TestCase):
 
     def setUp(self):
@@ -148,8 +152,8 @@ class TestSimpleReductionFunction(unittest.TestCase):
     'stream': ('null', 'new'),
     'ver': (2, 3),
 }))
-@pytest.mark.skipif(cupy.cuda.runtime.is_hip,
-                    reason='HIP does not support this')
+
+
 class TestReductionKernel(unittest.TestCase):
 
     def setUp(self):
@@ -192,8 +196,8 @@ class TestReductionKernel(unittest.TestCase):
     {'shape': (10, 10), 'slices': (slice(2, None), slice(2, None))},
     {'shape': (10, 10), 'slices': (slice(2, None), slice(4, None))},
 )
-@pytest.mark.skipif(cupy.cuda.runtime.is_hip,
-                    reason='HIP does not support this')
+
+
 class TestSlicingMemoryPointer(unittest.TestCase):
 
     @testing.for_all_dtypes_combination(names=['dtype'])
@@ -237,8 +241,6 @@ test_cases_with_stream = [
 
 
 @testing.parameterize(*test_cases_with_stream)
-@pytest.mark.skipif(cupy.cuda.runtime.is_hip,
-                    reason='HIP does not support this')
 class TestCUDAArrayInterfaceCompliance(unittest.TestCase):
 
     def setUp(self):
@@ -284,8 +286,8 @@ class TestCUDAArrayInterfaceCompliance(unittest.TestCase):
 @testing.parameterize(*testing.product({
     'stream': ('null', 'new', 'ptds'),
 }))
-@pytest.mark.skipif(cupy.cuda.runtime.is_hip,
-                    reason='HIP does not support this')
+
+
 class TestCUDAArrayInterfaceStream(unittest.TestCase):
     def setUp(self):
         if self.stream == 'null':

--- a/tests/cupy_tests/creation_tests/test_from_data.py
+++ b/tests/cupy_tests/creation_tests/test_from_data.py
@@ -570,8 +570,8 @@ max_cuda_array_interface_version = 3
     'ver': tuple(range(max_cuda_array_interface_version+1)),
     'strides': (False, None, True),
 }))
-@pytest.mark.skipif(
-    cupy.cuda.runtime.is_hip, reason='HIP does not support this')
+
+
 class TestCudaArrayInterface(unittest.TestCase):
     @testing.for_all_dtypes()
     def test_base(self, dtype):
@@ -640,8 +640,6 @@ class TestCudaArrayInterface(unittest.TestCase):
     'ver': tuple(range(1, max_cuda_array_interface_version+1)),
     'strides': (False, None, True),
 }))
-@pytest.mark.skipif(
-    cupy.cuda.runtime.is_hip, reason='HIP does not support this')
 class TestCudaArrayInterfaceMaskedArray(unittest.TestCase):
     # TODO(leofang): update this test when masked array is supported
     @testing.for_all_dtypes()
@@ -656,8 +654,6 @@ class TestCudaArrayInterfaceMaskedArray(unittest.TestCase):
 
 # marked slow as either numpy or cupy could go OOM in this test
 @testing.slow
-@pytest.mark.skipif(
-    cupy.cuda.runtime.is_hip, reason='HIP does not support this')
 class TestCudaArrayInterfaceBigArray(unittest.TestCase):
     def test_with_over_size_array(self):
         # real example from #3009
@@ -667,8 +663,6 @@ class TestCudaArrayInterfaceBigArray(unittest.TestCase):
         testing.assert_array_equal(a, b)
 
 
-@pytest.mark.skipif(
-    cupy.cuda.runtime.is_hip, reason='HIP does not support this')
 class DummyObjectWithCudaArrayInterface(object):
     def __init__(self, a, ver, include_strides=False, mask=None, stream=None):
         assert ver in tuple(range(max_cuda_array_interface_version+1))

--- a/tests/cupy_tests/creation_tests/test_from_data.py
+++ b/tests/cupy_tests/creation_tests/test_from_data.py
@@ -570,8 +570,6 @@ max_cuda_array_interface_version = 3
     'ver': tuple(range(max_cuda_array_interface_version+1)),
     'strides': (False, None, True),
 }))
-
-
 class TestCudaArrayInterface(unittest.TestCase):
     @testing.for_all_dtypes()
     def test_base(self, dtype):


### PR DESCRIPTION
This pull request does the following:

- Enabled cuda array interface for ROCm
- Modified existing attr unit test that was created for ROCm due to previous incomparability with cuda array interface. 
  - Rewrote unit test to check for attrs for both CUDA/ROCm.