### PR TITLE
Skip NCCL failing tests with hipErrorNoDevice 

### DIFF
--- a/tests/cupyx_tests/distributed_tests/test_comm.py
+++ b/tests/cupyx_tests/distributed_tests/test_comm.py
@@ -14,13 +14,29 @@ from cupy import testing
 from cupyx.distributed import init_process_group
 from cupyx.distributed._nccl_comm import _mpi_available
 
+import functools
 
 nccl_available = nccl.available
 
+def decorate_ifnot(cls_name, deco):
+    '''This decorator applies deco if method is not an instance of cls_name
+       The condition is checked only if its ROCm environment,
+       otherwise deco is applied directly'''
+    def decorater(method):
+        @functools.wraps(method)
+        def wrapper(instance, *args, **kwargs):
+            if runtime.is_hip and instance.__class__.__name__==cls_name:
+                return method(instance, *args, **kwargs)
+            else:
+                return deco(method)(instance, *args, **kwargs)
+        return wrapper 
+    return decorater
 
 def _run_test(test_name, dtype=None):
     # subprocess is required not to interfere with cupy module imported in top
     # of this file
+    if runtime.is_hip:
+        pytest.skip('ROCm/HIP may have a bug') 
     runner_path = pathlib.Path(__file__).parent / 'comm_runner.py'
     args = [sys.executable, runner_path, test_name, 'store']
     if dtype is not None:
@@ -54,55 +70,53 @@ def _run_test_with_mpi(test_name, dtype=None):
 
 
 @pytest.mark.skipif(not nccl_available, reason='nccl is not installed')
-@pytest.mark.skipif(runtime.is_hip, reason='ROCm/HIP may have a bug')
 @testing.multi_gpu(2)
 class TestNCCLBackend:
     def _run_test(self, test, dtype):
         _run_test(test, dtype)
 
-    @testing.for_all_dtypes(no_bool=True)
-    def test_broadcast(self, dtype):
+    @decorate_ifnot('TestNCCLBackend', testing.for_all_dtypes(no_bool=True))
+    def test_broadcast(self, dtype=None):
         self._run_test('broadcast', dtype)
 
-    @testing.for_all_dtypes(no_bool=True)
-    def test_reduce(self, dtype):
+    @decorate_ifnot('TestNCCLBackend', testing.for_all_dtypes(no_bool=True))
+    def test_reduce(self, dtype=None):
         self._run_test('reduce', dtype)
 
-    @testing.for_all_dtypes(no_bool=True)
-    def test_all_reduce(self, dtype):
+    @decorate_ifnot('TestNCCLBackend', testing.for_all_dtypes(no_bool=True))
+    def test_all_reduce(self, dtype=None):
         self._run_test('all_reduce', dtype)
 
-    @testing.for_all_dtypes(no_bool=True)
-    def test_reduce_scatter(self, dtype):
+    @decorate_ifnot('TestNCCLBackend', testing.for_all_dtypes(no_bool=True))
+    def test_reduce_scatter(self, dtype=None):
         self._run_test('reduce_scatter', dtype)
 
-    @testing.for_all_dtypes(no_bool=True)
-    def test_all_gather(self, dtype):
+    @decorate_ifnot('TestNCCLBackend', testing.for_all_dtypes(no_bool=True))
+    def test_all_gather(self, dtype=None):
         self._run_test('all_gather', dtype)
 
-    @testing.for_all_dtypes(no_bool=True)
-    def test_send_and_recv(self, dtype):
+    @decorate_ifnot('TestNCCLBackend', testing.for_all_dtypes(no_bool=True))
+    def test_send_and_recv(self, dtype=None):
         self._run_test('send_and_recv', dtype)
 
-    @testing.for_all_dtypes(no_bool=True)
-    def test_send_recv(self, dtype):
+    @decorate_ifnot('TestNCCLBackend', testing.for_all_dtypes(no_bool=True))
+    def test_send_recv(self, dtype=None):
         self._run_test('send_recv', dtype)
 
-    @testing.for_all_dtypes(no_bool=True)
-    def test_scatter(self, dtype):
+    @decorate_ifnot('TestNCCLBackend', testing.for_all_dtypes(no_bool=True))
+    def test_scatter(self, dtype=None):
         self._run_test('scatter', dtype)
 
-    @testing.for_all_dtypes(no_bool=True)
-    def test_gather(self, dtype):
+    @decorate_ifnot('TestNCCLBackend', testing.for_all_dtypes(no_bool=True))
+    def test_gather(self, dtype=None):
         self._run_test('gather', dtype)
 
-    @testing.for_all_dtypes(no_bool=True)
-    def test_all_to_all(self, dtype):
+    @decorate_ifnot('TestNCCLBackend', testing.for_all_dtypes(no_bool=True))
+    def test_all_to_all(self, dtype=None):
         self._run_test('all_to_all', dtype)
 
     def test_barrier(self):
         self._run_test('barrier', None)
-
 
 @pytest.mark.skipif(not _mpi_available, reason='mpi is not installed')
 @testing.multi_gpu(2)
@@ -112,50 +126,49 @@ class TestNCCLBackendWithMPI(TestNCCLBackend):
 
 
 @pytest.mark.skipif(not nccl_available, reason='nccl is not installed')
-@pytest.mark.skipif(runtime.is_hip, reason='ROCm/HIP may have a bug')
 @testing.multi_gpu(2)
 class TestNCCLBackendSparse:
     def _run_test(self, test, dtype):
         _run_test(test, dtype)
 
-    @testing.for_dtypes('fdFD')
-    def test_send_and_recv(self, dtype):
+    @decorate_ifnot('TestNCCLBackendSparse', testing.for_dtypes('fdFD'))
+    def test_send_and_recv(self, dtype=None):
         self._run_test('sparse_send_and_recv', dtype)
 
-    @testing.for_dtypes('fdFD')
-    def test_broadcast(self, dtype):
+    @decorate_ifnot('TestNCCLBackendSparse', testing.for_dtypes('fdFD'))
+    def test_broadcast(self, dtype=None):
         self._run_test('sparse_broadcast', dtype)
 
-    @testing.for_dtypes('fdFD')
-    def test_reduce(self, dtype):
+    @decorate_ifnot('TestNCCLBackendSparse', testing.for_dtypes('fdFD'))
+    def test_reduce(self, dtype=None):
         self._run_test('sparse_reduce', dtype)
 
-    @testing.for_dtypes('fdFD')
-    def test_all_reduce(self, dtype):
+    @decorate_ifnot('TestNCCLBackendSparse', testing.for_dtypes('fdFD'))
+    def test_all_reduce(self, dtype=None):
         self._run_test('sparse_all_reduce', dtype)
 
-    @testing.for_dtypes('fdFD')
-    def test_scatter(self, dtype):
+    @decorate_ifnot('TestNCCLBackendSparse', testing.for_dtypes('fdFD'))
+    def test_scatter(self, dtype=None):
         self._run_test('sparse_scatter', dtype)
 
-    @testing.for_dtypes('fdFD')
-    def test_gather(self, dtype):
+    @decorate_ifnot('TestNCCLBackendSparse', testing.for_dtypes('fdFD'))
+    def test_gather(self, dtype=None):
         self._run_test('sparse_gather', dtype)
 
-    @testing.for_dtypes('fdFD')
-    def test_all_gather(self, dtype):
+    @decorate_ifnot('TestNCCLBackendSparse', testing.for_dtypes('fdFD'))
+    def test_all_gather(self, dtype=None):
         self._run_test('sparse_all_gather', dtype)
 
-    @testing.for_dtypes('fdFD')
-    def test_all_to_all(self, dtype):
+    @decorate_ifnot('TestNCCLBackendSparse', testing.for_dtypes('fdFD'))
+    def test_all_to_all(self, dtype=None):
         self._run_test('sparse_all_to_all', dtype)
 
-    @testing.for_dtypes('fdFD')
-    def test_reduce_scatter(self, dtype):
+    @decorate_ifnot('TestNCCLBackendSparse', testing.for_dtypes('fdFD'))
+    def test_reduce_scatter(self, dtype=None):
         self._run_test('sparse_reduce_scatter', dtype)
 
-    @testing.for_dtypes('fdFD')
-    def test_send_recv(self, dtype):
+    @decorate_ifnot('TestNCCLBackendSparse', testing.for_dtypes('fdFD'))
+    def test_send_recv(self, dtype=None):
         self._run_test('sparse_send_recv', dtype)
 
 
@@ -169,8 +182,8 @@ class TestNCCLBackendSparseWithMPI(TestNCCLBackendSparse):
 @pytest.mark.skipif(not nccl_available, reason='nccl is not installed')
 class TestInitDistributed(unittest.TestCase):
 
-    @pytest.mark.skipif(runtime.is_hip, reason='ROCm/HIP may have a bug')
     @testing.multi_gpu(2)
+    @pytest.mark.skipif(runtime.is_hip, reason='ROCm/HIP may have a bug')
     def test_init(self):
         _run_test('init')
 

--- a/tests/cupyx_tests/distributed_tests/test_comm.py
+++ b/tests/cupyx_tests/distributed_tests/test_comm.py
@@ -18,6 +18,7 @@ import functools
 
 nccl_available = nccl.available
 
+
 def decorate_ifnot(cls_name, deco):
     '''This decorator applies deco if method is not an instance of cls_name
        The condition is checked only if its ROCm environment,
@@ -25,18 +26,19 @@ def decorate_ifnot(cls_name, deco):
     def decorater(method):
         @functools.wraps(method)
         def wrapper(instance, *args, **kwargs):
-            if runtime.is_hip and instance.__class__.__name__==cls_name:
+            if runtime.is_hip and instance.__class__.__name__ == cls_name:
                 return method(instance, *args, **kwargs)
             else:
                 return deco(method)(instance, *args, **kwargs)
-        return wrapper 
+        return wrapper
     return decorater
+
 
 def _run_test(test_name, dtype=None):
     # subprocess is required not to interfere with cupy module imported in top
     # of this file
     if runtime.is_hip:
-        pytest.skip('ROCm/HIP may have a bug') 
+        pytest.skip('ROCm/HIP may have a bug')
     runner_path = pathlib.Path(__file__).parent / 'comm_runner.py'
     args = [sys.executable, runner_path, test_name, 'store']
     if dtype is not None:

--- a/tests/cupyx_tests/distributed_tests/test_comm.py
+++ b/tests/cupyx_tests/distributed_tests/test_comm.py
@@ -8,6 +8,7 @@ import numpy
 import pytest
 
 from cupy.cuda import nccl
+from cupy.cuda import runtime
 from cupy import testing
 
 from cupyx.distributed import init_process_group
@@ -53,6 +54,7 @@ def _run_test_with_mpi(test_name, dtype=None):
 
 
 @pytest.mark.skipif(not nccl_available, reason='nccl is not installed')
+@pytest.mark.skipif(runtime.is_hip, reason='ROCm/HIP may have a bug')
 @testing.multi_gpu(2)
 class TestNCCLBackend:
     def _run_test(self, test, dtype):
@@ -110,6 +112,7 @@ class TestNCCLBackendWithMPI(TestNCCLBackend):
 
 
 @pytest.mark.skipif(not nccl_available, reason='nccl is not installed')
+@pytest.mark.skipif(runtime.is_hip, reason='ROCm/HIP may have a bug')
 @testing.multi_gpu(2)
 class TestNCCLBackendSparse:
     def _run_test(self, test, dtype):
@@ -166,6 +169,7 @@ class TestNCCLBackendSparseWithMPI(TestNCCLBackendSparse):
 @pytest.mark.skipif(not nccl_available, reason='nccl is not installed')
 class TestInitDistributed(unittest.TestCase):
 
+    @pytest.mark.skipif(runtime.is_hip, reason='ROCm/HIP may have a bug')
     @testing.multi_gpu(2)
     def test_init(self):
         _run_test('init')

--- a/tests/cupyx_tests/distributed_tests/test_comm.py
+++ b/tests/cupyx_tests/distributed_tests/test_comm.py
@@ -118,6 +118,7 @@ class TestNCCLBackend:
     def test_barrier(self):
         self._run_test('barrier', None)
 
+
 @pytest.mark.skipif(not _mpi_available, reason='mpi is not installed')
 @testing.multi_gpu(2)
 class TestNCCLBackendWithMPI(TestNCCLBackend):


### PR DESCRIPTION
This PR skips NCCL failing tests with hipErrorNoDevice error
cupy_backends.cuda.api.runtime_hip.CUDARuntimeError: hipErrorNoDevice: no ROCm-capable device is detected

NCCL tests summary after this change:
tests/cupyx_tests/distributed_tests/test_comm.py::TestNCCLBackend::test_broadcast SKIPPED (ROCm/HIP may have a bug)
tests/cupyx_tests/distributed_tests/test_comm.py::TestNCCLBackend::test_reduce SKIPPED (ROCm/HIP may have a bug)
tests/cupyx_tests/distributed_tests/test_comm.py::TestNCCLBackend::test_all_reduce SKIPPED (ROCm/HIP may have a bug)
tests/cupyx_tests/distributed_tests/test_comm.py::TestNCCLBackend::test_reduce_scatter SKIPPED (ROCm/HIP may have a bug)
tests/cupyx_tests/distributed_tests/test_comm.py::TestNCCLBackend::test_all_gather SKIPPED (ROCm/HIP may have a bug)
tests/cupyx_tests/distributed_tests/test_comm.py::TestNCCLBackend::test_send_and_recv SKIPPED (ROCm/HIP may have a bug)
tests/cupyx_tests/distributed_tests/test_comm.py::TestNCCLBackend::test_send_recv SKIPPED (ROCm/HIP may have a bug)
tests/cupyx_tests/distributed_tests/test_comm.py::TestNCCLBackend::test_scatter SKIPPED (ROCm/HIP may have a bug)
tests/cupyx_tests/distributed_tests/test_comm.py::TestNCCLBackend::test_gather SKIPPED (ROCm/HIP may have a bug)
tests/cupyx_tests/distributed_tests/test_comm.py::TestNCCLBackend::test_all_to_all SKIPPED (ROCm/HIP may have a bug)
tests/cupyx_tests/distributed_tests/test_comm.py::TestNCCLBackend::test_barrier SKIPPED (ROCm/HIP may have a bug)
tests/cupyx_tests/distributed_tests/test_comm.py::TestNCCLBackendWithMPI::test_broadcast SKIPPED (ROCm/HIP may have a bug)
tests/cupyx_tests/distributed_tests/test_comm.py::TestNCCLBackendWithMPI::test_reduce SKIPPED (ROCm/HIP may have a bug)
tests/cupyx_tests/distributed_tests/test_comm.py::TestNCCLBackendWithMPI::test_all_reduce SKIPPED (ROCm/HIP may have a bug)
tests/cupyx_tests/distributed_tests/test_comm.py::TestNCCLBackendWithMPI::test_reduce_scatter SKIPPED (ROCm/HIP may have a bug)
tests/cupyx_tests/distributed_tests/test_comm.py::TestNCCLBackendWithMPI::test_all_gather SKIPPED (ROCm/HIP may have a bug)
tests/cupyx_tests/distributed_tests/test_comm.py::TestNCCLBackendWithMPI::test_send_and_recv SKIPPED (ROCm/HIP may have a bug)
tests/cupyx_tests/distributed_tests/test_comm.py::TestNCCLBackendWithMPI::test_send_recv SKIPPED (ROCm/HIP may have a bug)
tests/cupyx_tests/distributed_tests/test_comm.py::TestNCCLBackendWithMPI::test_scatter SKIPPED (ROCm/HIP may have a bug)
tests/cupyx_tests/distributed_tests/test_comm.py::TestNCCLBackendWithMPI::test_gather SKIPPED (ROCm/HIP may have a bug)
tests/cupyx_tests/distributed_tests/test_comm.py::TestNCCLBackendWithMPI::test_all_to_all SKIPPED (ROCm/HIP may have a bug)
tests/cupyx_tests/distributed_tests/test_comm.py::TestNCCLBackendWithMPI::test_barrier SKIPPED (ROCm/HIP may have a bug)
tests/cupyx_tests/distributed_tests/test_comm.py::TestNCCLBackendSparse::test_send_and_recv SKIPPED (ROCm/HIP may have a bug)
tests/cupyx_tests/distributed_tests/test_comm.py::TestNCCLBackendSparse::test_broadcast SKIPPED (ROCm/HIP may have a bug)
tests/cupyx_tests/distributed_tests/test_comm.py::TestNCCLBackendSparse::test_reduce SKIPPED (ROCm/HIP may have a bug)
tests/cupyx_tests/distributed_tests/test_comm.py::TestNCCLBackendSparse::test_all_reduce SKIPPED (ROCm/HIP may have a bug)
tests/cupyx_tests/distributed_tests/test_comm.py::TestNCCLBackendSparse::test_scatter SKIPPED (ROCm/HIP may have a bug)
tests/cupyx_tests/distributed_tests/test_comm.py::TestNCCLBackendSparse::test_gather SKIPPED (ROCm/HIP may have a bug)
tests/cupyx_tests/distributed_tests/test_comm.py::TestNCCLBackendSparse::test_all_gather SKIPPED (ROCm/HIP may have a bug)
tests/cupyx_tests/distributed_tests/test_comm.py::TestNCCLBackendSparse::test_all_to_all SKIPPED (ROCm/HIP may have a bug)
tests/cupyx_tests/distributed_tests/test_comm.py::TestNCCLBackendSparse::test_reduce_scatter SKIPPED (ROCm/HIP may have a bug)
tests/cupyx_tests/distributed_tests/test_comm.py::TestNCCLBackendSparse::test_send_recv SKIPPED (ROCm/HIP may have a bug)
tests/cupyx_tests/distributed_tests/test_comm.py::TestNCCLBackendSparseWithMPI::test_send_and_recv SKIPPED (ROCm/HIP may have a bug)
tests/cupyx_tests/distributed_tests/test_comm.py::TestNCCLBackendSparseWithMPI::test_broadcast SKIPPED (ROCm/HIP may have a bug)
tests/cupyx_tests/distributed_tests/test_comm.py::TestNCCLBackendSparseWithMPI::test_reduce SKIPPED (ROCm/HIP may have a bug)
tests/cupyx_tests/distributed_tests/test_comm.py::TestNCCLBackendSparseWithMPI::test_all_reduce SKIPPED (ROCm/HIP may have a bug)
tests/cupyx_tests/distributed_tests/test_comm.py::TestNCCLBackendSparseWithMPI::test_scatter SKIPPED (ROCm/HIP may have a bug)
tests/cupyx_tests/distributed_tests/test_comm.py::TestNCCLBackendSparseWithMPI::test_gather SKIPPED (ROCm/HIP may have a bug)
tests/cupyx_tests/distributed_tests/test_comm.py::TestNCCLBackendSparseWithMPI::test_all_gather SKIPPED (ROCm/HIP may have a bug)
tests/cupyx_tests/distributed_tests/test_comm.py::TestNCCLBackendSparseWithMPI::test_all_to_all SKIPPED (ROCm/HIP may have a bug)
tests/cupyx_tests/distributed_tests/test_comm.py::TestNCCLBackendSparseWithMPI::test_reduce_scatter SKIPPED (ROCm/HIP may have a bug)
tests/cupyx_tests/distributed_tests/test_comm.py::TestNCCLBackendSparseWithMPI::test_send_recv SKIPPED (ROCm/HIP may have a bug)
tests/cupyx_tests/distributed_tests/test_comm.py::TestInitDistributed::test_init SKIPPED (ROCm/HIP may have a bug)
tests/cupyx_tests/distributed_tests/test_comm.py::TestInitDistributed::test_invalid_backend PASSED
tests/cupyx_tests/distributed_tests/test_comm.py::TestInitDistributed::test_invalid_n_devices PASSED
tests/cupyx_tests/distributed_tests/test_comm.py::TestInitDistributed::test_invalid_rank PASSED

=================================================== 3 passed, 43 skipped in 0.95s ===================================================