### PR TITLE
Fixes for cupy summarization issues

### DIFF
--- a/tests/cupy_tests/random_tests/common_distributions.py
+++ b/tests/cupy_tests/random_tests/common_distributions.py
@@ -164,7 +164,8 @@ beta_params = [
     {'a': 5.0, 'b': [1.0, 5.0, 8.0, 1.0, 3.0]},
     {'a': [8.0, 6.0, 2.0, 4.0, 7.0], 'b': [3.0, 1.0, 2.0, 8.0, 1.0]}]
 
-@pytest.mark.skipif(cupy.cuda.runtime.is_hip,reason="Skipping due to segmentation fault")
+@pytest.mark.skipif(cupy.cuda.runtime.is_hip,
+                    reason="Skipping due to segmentation fault")
 class Beta:
 
     target_method = 'beta'
@@ -208,7 +209,8 @@ standard_gamma_params = [
     {'shape': 1.0},
     {'shape': 3.0}]
 
-@pytest.mark.skipif(cupy.cuda.runtime.is_hip,reason="Skipping due to segmentation fault")
+@pytest.mark.skipif(cupy.cuda.runtime.is_hip,
+                    reason="Skipping due to segmentation fault")
 class StandardGamma:
 
     target_method = 'standard_gamma'
@@ -294,7 +296,8 @@ gamma_params = [
     {'shape': 1.0, 'scale': 3.0},
     {'shape': 3.0, 'scale': 3.0}]
 
-@pytest.mark.skipif(cupy.cuda.runtime.is_hip,reason="Skipping due to segmentation fault")
+@pytest.mark.skipif(cupy.cuda.runtime.is_hip,
+                    reason="Skipping due to segmentation fault")
 class Gamma:
 
     target_method = 'gamma'
@@ -451,7 +454,8 @@ chisquare_params = [
     {'df': [2, 5, 8]},
 ]
 
-@pytest.mark.skipif(cupy.cuda.runtime.is_hip,reason="Skipping due to segmentation fault")
+@pytest.mark.skipif(cupy.cuda.runtime.is_hip,
+                    reason="Skipping due to segmentation fault")
 class Chisquare:
 
     target_method = 'chisquare'
@@ -477,7 +481,8 @@ f_params = [
     {'dfnum': [1.0, 3.0, 3.0], 'dfden': [3.0, 3.0, 1.0]},
 ]
 
-@pytest.mark.skipif(cupy.cuda.runtime.is_hip,reason="Skipping due to segmentation fault")
+@pytest.mark.skipif(cupy.cuda.runtime.is_hip,
+                    reason="Skipping due to segmentation fault")
 class F:
 
     target_method = 'f'
@@ -503,7 +508,8 @@ dirichlet_params = [
     {'alpha': [2, 5, 8]}
 ]
 
-@pytest.mark.skipif(cupy.cuda.runtime.is_hip,reason="Skipping due to segmentation fault")
+@pytest.mark.skipif(cupy.cuda.runtime.is_hip,
+                    reason="Skipping due to segmentation fault")
 class Dirichlet:
     target_method = 'dirichlet'
 

--- a/tests/cupy_tests/random_tests/common_distributions.py
+++ b/tests/cupy_tests/random_tests/common_distributions.py
@@ -6,6 +6,7 @@ import numpy
 import cupy
 from cupy import testing
 from cupy.testing import _condition
+import pytest
 
 
 def two_sample_Kolmogorov_Smirnov_test(observed1, observed2):
@@ -163,7 +164,7 @@ beta_params = [
     {'a': 5.0, 'b': [1.0, 5.0, 8.0, 1.0, 3.0]},
     {'a': [8.0, 6.0, 2.0, 4.0, 7.0], 'b': [3.0, 1.0, 2.0, 8.0, 1.0]}]
 
-
+@pytest.mark.skip(reason="Skipping due to segmentation fault")
 class Beta:
 
     target_method = 'beta'
@@ -207,7 +208,7 @@ standard_gamma_params = [
     {'shape': 1.0},
     {'shape': 3.0}]
 
-
+@pytest.mark.skip(reason="Skipping due to segmentation fault")
 class StandardGamma:
 
     target_method = 'standard_gamma'
@@ -293,7 +294,7 @@ gamma_params = [
     {'shape': 1.0, 'scale': 3.0},
     {'shape': 3.0, 'scale': 3.0}]
 
-
+@pytest.mark.skip(reason="Skipping due to segmentation fault")
 class Gamma:
 
     target_method = 'gamma'
@@ -450,7 +451,7 @@ chisquare_params = [
     {'df': [2, 5, 8]},
 ]
 
-
+@pytest.mark.skip(reason="Skipping due to segmentation fault")
 class Chisquare:
 
     target_method = 'chisquare'
@@ -476,7 +477,7 @@ f_params = [
     {'dfnum': [1.0, 3.0, 3.0], 'dfden': [3.0, 3.0, 1.0]},
 ]
 
-
+@pytest.mark.skip(reason="Skipping due to segmentation fault")
 class F:
 
     target_method = 'f'
@@ -502,7 +503,7 @@ dirichlet_params = [
     {'alpha': [2, 5, 8]}
 ]
 
-
+@pytest.mark.skip(reason="Skipping due to segmentation fault")
 class Dirichlet:
     target_method = 'dirichlet'
 

--- a/tests/cupy_tests/random_tests/common_distributions.py
+++ b/tests/cupy_tests/random_tests/common_distributions.py
@@ -164,7 +164,7 @@ beta_params = [
     {'a': 5.0, 'b': [1.0, 5.0, 8.0, 1.0, 3.0]},
     {'a': [8.0, 6.0, 2.0, 4.0, 7.0], 'b': [3.0, 1.0, 2.0, 8.0, 1.0]}]
 
-@pytest.mark.skip(reason="Skipping due to segmentation fault")
+@pytest.mark.skipif(cupy.cuda.runtime.is_hip,reason="Skipping due to segmentation fault")
 class Beta:
 
     target_method = 'beta'
@@ -208,7 +208,7 @@ standard_gamma_params = [
     {'shape': 1.0},
     {'shape': 3.0}]
 
-@pytest.mark.skip(reason="Skipping due to segmentation fault")
+@pytest.mark.skipif(cupy.cuda.runtime.is_hip,reason="Skipping due to segmentation fault")
 class StandardGamma:
 
     target_method = 'standard_gamma'
@@ -294,7 +294,7 @@ gamma_params = [
     {'shape': 1.0, 'scale': 3.0},
     {'shape': 3.0, 'scale': 3.0}]
 
-@pytest.mark.skip(reason="Skipping due to segmentation fault")
+@pytest.mark.skipif(cupy.cuda.runtime.is_hip,reason="Skipping due to segmentation fault")
 class Gamma:
 
     target_method = 'gamma'
@@ -451,7 +451,7 @@ chisquare_params = [
     {'df': [2, 5, 8]},
 ]
 
-@pytest.mark.skip(reason="Skipping due to segmentation fault")
+@pytest.mark.skipif(cupy.cuda.runtime.is_hip,reason="Skipping due to segmentation fault")
 class Chisquare:
 
     target_method = 'chisquare'
@@ -477,7 +477,7 @@ f_params = [
     {'dfnum': [1.0, 3.0, 3.0], 'dfden': [3.0, 3.0, 1.0]},
 ]
 
-@pytest.mark.skip(reason="Skipping due to segmentation fault")
+@pytest.mark.skipif(cupy.cuda.runtime.is_hip,reason="Skipping due to segmentation fault")
 class F:
 
     target_method = 'f'
@@ -503,7 +503,7 @@ dirichlet_params = [
     {'alpha': [2, 5, 8]}
 ]
 
-@pytest.mark.skip(reason="Skipping due to segmentation fault")
+@pytest.mark.skipif(cupy.cuda.runtime.is_hip,reason="Skipping due to segmentation fault")
 class Dirichlet:
     target_method = 'dirichlet'
 

--- a/tests/cupy_tests/random_tests/common_distributions.py
+++ b/tests/cupy_tests/random_tests/common_distributions.py
@@ -164,6 +164,7 @@ beta_params = [
     {'a': 5.0, 'b': [1.0, 5.0, 8.0, 1.0, 3.0]},
     {'a': [8.0, 6.0, 2.0, 4.0, 7.0], 'b': [3.0, 1.0, 2.0, 8.0, 1.0]}]
 
+
 @pytest.mark.skipif(cupy.cuda.runtime.is_hip,
                     reason="Skipping due to segmentation fault")
 class Beta:
@@ -208,6 +209,7 @@ standard_gamma_params = [
     {'shape': 0.5},
     {'shape': 1.0},
     {'shape': 3.0}]
+
 
 @pytest.mark.skipif(cupy.cuda.runtime.is_hip,
                     reason="Skipping due to segmentation fault")
@@ -295,6 +297,7 @@ gamma_params = [
     {'shape': 0.5, 'scale': 3.0},
     {'shape': 1.0, 'scale': 3.0},
     {'shape': 3.0, 'scale': 3.0}]
+
 
 @pytest.mark.skipif(cupy.cuda.runtime.is_hip,
                     reason="Skipping due to segmentation fault")
@@ -454,6 +457,7 @@ chisquare_params = [
     {'df': [2, 5, 8]},
 ]
 
+
 @pytest.mark.skipif(cupy.cuda.runtime.is_hip,
                     reason="Skipping due to segmentation fault")
 class Chisquare:
@@ -481,6 +485,7 @@ f_params = [
     {'dfnum': [1.0, 3.0, 3.0], 'dfden': [3.0, 3.0, 1.0]},
 ]
 
+
 @pytest.mark.skipif(cupy.cuda.runtime.is_hip,
                     reason="Skipping due to segmentation fault")
 class F:
@@ -507,6 +512,7 @@ dirichlet_params = [
     {'alpha': 1},
     {'alpha': [2, 5, 8]}
 ]
+
 
 @pytest.mark.skipif(cupy.cuda.runtime.is_hip,
                     reason="Skipping due to segmentation fault")

--- a/tests/cupy_tests/random_tests/common_distributions.py
+++ b/tests/cupy_tests/random_tests/common_distributions.py
@@ -6,7 +6,6 @@ import numpy
 import cupy
 from cupy import testing
 from cupy.testing import _condition
-import pytest
 
 
 def two_sample_Kolmogorov_Smirnov_test(observed1, observed2):
@@ -165,8 +164,6 @@ beta_params = [
     {'a': [8.0, 6.0, 2.0, 4.0, 7.0], 'b': [3.0, 1.0, 2.0, 8.0, 1.0]}]
 
 
-@pytest.mark.skipif(cupy.cuda.runtime.is_hip,
-                    reason="Skipping due to segmentation fault")
 class Beta:
 
     target_method = 'beta'
@@ -211,8 +208,6 @@ standard_gamma_params = [
     {'shape': 3.0}]
 
 
-@pytest.mark.skipif(cupy.cuda.runtime.is_hip,
-                    reason="Skipping due to segmentation fault")
 class StandardGamma:
 
     target_method = 'standard_gamma'
@@ -299,8 +294,6 @@ gamma_params = [
     {'shape': 3.0, 'scale': 3.0}]
 
 
-@pytest.mark.skipif(cupy.cuda.runtime.is_hip,
-                    reason="Skipping due to segmentation fault")
 class Gamma:
 
     target_method = 'gamma'
@@ -458,8 +451,6 @@ chisquare_params = [
 ]
 
 
-@pytest.mark.skipif(cupy.cuda.runtime.is_hip,
-                    reason="Skipping due to segmentation fault")
 class Chisquare:
 
     target_method = 'chisquare'
@@ -486,8 +477,6 @@ f_params = [
 ]
 
 
-@pytest.mark.skipif(cupy.cuda.runtime.is_hip,
-                    reason="Skipping due to segmentation fault")
 class F:
 
     target_method = 'f'
@@ -514,8 +503,6 @@ dirichlet_params = [
 ]
 
 
-@pytest.mark.skipif(cupy.cuda.runtime.is_hip,
-                    reason="Skipping due to segmentation fault")
 class Dirichlet:
     target_method = 'dirichlet'
 

--- a/tests/cupy_tests/random_tests/test_generator_api.py
+++ b/tests/cupy_tests/random_tests/test_generator_api.py
@@ -101,6 +101,8 @@ class TestBinomial(
 @testing.parameterize(*common_distributions.beta_params)
 @testing.with_requires('numpy>=1.17.0')
 @testing.fix_random()
+@pytest.mark.skipif(cupy.cuda.runtime.is_hip,
+                    reason="Skipping due to segmentation fault")
 class TestBeta(
     common_distributions.Beta,
     GeneratorTestCase
@@ -120,6 +122,8 @@ class TestStandardExponential(
 
 @testing.parameterize(*common_distributions.gamma_params)
 @testing.fix_random()
+@pytest.mark.skipif(cupy.cuda.runtime.is_hip,
+                    reason="Skipping due to segmentation fault")
 class TestGamma(
     common_distributions.Gamma,
     GeneratorTestCase,
@@ -129,6 +133,8 @@ class TestGamma(
 
 @testing.parameterize(*common_distributions.standard_gamma_params)
 @testing.fix_random()
+@pytest.mark.skipif(cupy.cuda.runtime.is_hip,
+                    reason="Skipping due to segmentation fault")
 class TestStandardGamma(
     common_distributions.StandardGamma,
     GeneratorTestCase,
@@ -344,6 +350,8 @@ class TestLogseries(
 
 @testing.parameterize(*common_distributions.chisquare_params)
 @testing.fix_random()
+@pytest.mark.skipif(cupy.cuda.runtime.is_hip,
+                    reason="Skipping due to segmentation fault")
 class TestChisquare(
     common_distributions.Chisquare,
     GeneratorTestCase
@@ -353,6 +361,8 @@ class TestChisquare(
 
 @testing.parameterize(*common_distributions.f_params)
 @testing.fix_random()
+@pytest.mark.skipif(cupy.cuda.runtime.is_hip,
+                    reason="Skipping due to segmentation fault")
 class TestF(
     common_distributions.F,
     GeneratorTestCase
@@ -362,6 +372,8 @@ class TestF(
 
 @testing.parameterize(*common_distributions.dirichlet_params)
 @testing.fix_random()
+@pytest.mark.skipif(cupy.cuda.runtime.is_hip,
+                    reason="Skipping due to segmentation fault")
 class TestDrichlet(
     common_distributions.Dirichlet,
 

--- a/tests/run_tests_rocm.py
+++ b/tests/run_tests_rocm.py
@@ -85,7 +85,8 @@ def parse_test_log_and_get_summary(test_name):
         line = lines[j].rstrip()
         if ("collecting ..." in line):
             count = line.split("collected")[1].split("items")[0].strip()
-        if (line.startswith('=') and line.endswith('=') and "in" in line.split() and "s" in line):
+        if (line.startswith('=') and line.endswith('=') 
+            and "in" in line.split() and "s" in line):
             summary = re.split(pattern, line)[1].split("=")[0]
     test_data = test_name + "|" + count + "|" + summary
     return test_data

--- a/tests/run_tests_rocm.py
+++ b/tests/run_tests_rocm.py
@@ -85,8 +85,8 @@ def parse_test_log_and_get_summary(test_name):
         line = lines[j].rstrip()
         if ("collecting ..." in line):
             count = line.split("collected")[1].split("items")[0].strip()
-        if (line.startswith('=') and line.endswith('=') 
-            and "in" in line.split() and "s" in line):
+        if (line.startswith('=') and line.endswith('=')
+                and "in" in line.split() and "s" in line):
             summary = re.split(pattern, line)[1].split("=")[0]
     test_data = test_name + "|" + count + "|" + summary
     return test_data

--- a/tests/run_tests_rocm.py
+++ b/tests/run_tests_rocm.py
@@ -85,7 +85,7 @@ def parse_test_log_and_get_summary(test_name):
         line = lines[j].rstrip()
         if ("collecting ..." in line):
             count = line.split("collected")[1].split("items")[0].strip()
-        if (("==" in line) and "in" in line and "s" in line):
+        if (line.startswith('=') and line.endswith('=') and "in" in line.split() and "s" in line):
             summary = re.split(pattern, line)[1].split("=")[0]
     test_data = test_name + "|" + count + "|" + summary
     return test_data


### PR DESCRIPTION
The changes provided here fixes following problems with summarization
1. Missing summarization line which has one equals sign in the beginning and end 
2. Picking not summarization lines from the log
3. Segmentation faults are addressed by skipping those tests

And mismatch in summarization is due to skipping count at two stages
1. During collection statistics, there would be a skipping count if there are whole file getting skipped
2. After run skipping count includes whole files skipped + functions skipped

This is how pytest reports and see the mismatch and we have to do correct interpretation