### PR TITLE
Add __HIP__ macro to avoid cccl config import in thrust

### DIFF
--- a/install/cupy_builder/cupy_setup_build.py
+++ b/install/cupy_builder/cupy_setup_build.py
@@ -324,6 +324,7 @@ def make_extensions(ctx: Context, compiler, use_cython):
         settings['define_macros'].append(('CUPY_NO_CUDA', '1'))
     if use_hip:
         settings['define_macros'].append(('CUPY_USE_HIP', '1'))
+        settings['define_macros'].append(('__HIP__', '1'))
         # introduced since ROCm 4.2.0
         settings['define_macros'].append(('__HIP_PLATFORM_AMD__', '1'))
         # deprecated since ROCm 4.2.0


### PR DESCRIPTION
Thrust imports cccl_config in cuda and uses __HIP__ definition to decide on it. This PR defines macro for ROCm during the build.