### PR TITLE
raise TypeError if buffer protocol is not meant to be supported

### DIFF
--- a/cupy/_core/core.pyx
+++ b/cupy/_core/core.pyx
@@ -392,7 +392,7 @@ cdef class _ndarray_base:
         # TODO(leofang): use flags
         if (not is_ump_supported(self.data.device_id)
                 or not self.is_host_accessible()):
-            raise RuntimeError(
+            raise TypeError(
                 'Accessing a CuPy ndarry on CPU is not allowed except when '
                 'using system memory (on HMM or ATS enabled systems, need to '
                 'set CUPY_ENABLE_UMP=1) or managed memory')

--- a/cupy/_core/dlpack.pyx
+++ b/cupy/_core/dlpack.pyx
@@ -102,7 +102,7 @@ cdef DLDevice get_dlpack_device(_ndarray_base array):
 # The name of this function is following the framework integration guide of
 # TensorComprehensions.
 cpdef object toDlpack(
-    _ndarray_base array, bint use_versioned=True, bint to_cpu=False,
+    _ndarray_base array, bint use_versioned=False, bint to_cpu=False,
     bint ensure_copy=False, stream=None
 ) except +:
     """Create a dlpack capsule for an array.


### PR DESCRIPTION
> [!CAUTION]
> WIP

Cherry-picking similar recent commit from upstream `cupy/cupy`.

# TODOs

Likely need to make further changes to:

* [ ] ensure backwards compatibility with older Numba versions
* [ ] Fix issues with integration tests.